### PR TITLE
Added support for the new separate Lifetime installer. Small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Outsystems.SetupTools Release History
 
+## Unreleased
+
+### What's new
+
+- Added support for Lifetime in Install-OSServer and Get-OSRepoAvailableVersions
+
+### Changes
+
+- Fixed Install-OSServer. Now checks if an empty -InstallDir parameter is specified.
+
 ## 2.2.0.0
 
 ### What's new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### Changes
 
-- Fixed Install-OSServer. Now checks if an empty -InstallDir parameter is specified.
+- Fixed Install-OSServer. Now throws if an empty/null -InstallDir, -SourcePath and -Version parameters is specified.
+- Fixed Install-OSServiceStudio. Now throws if an empty/null -InstallDir, -SourcePath and -Version parameters is specified.
 
 ## 2.2.0.0
 

--- a/src/Outsystems.SetupTools/Functions/Get-OSRepoAvailableVersions.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSRepoAvailableVersions.ps1
@@ -8,6 +8,17 @@ function Get-OSRepoAvailableVersions
     This will list the available OutSystems applications versions available in the online repository
     Usefull for the Install-OSServer and Install-OSServiceStudio cmdLets
 
+    .PARAMETER Application
+    Specifies which application to retrieve the version
+    This can be 'PlatformServer', 'ServiceStudio', 'Lifetime'
+
+    .PARAMETER MajorVersion
+    Specifies the platform major version
+    Accepted values: 10.0 or 11.0
+
+    .PARAMETER Latest
+    If specified, will only return the latest version
+
     .EXAMPLE
     Get all available versions of the OutSystems 10 platform server
     Get-OSRepoAvailableVersions -Application 'PlatformServer' -MajorVersion '10.0'
@@ -22,7 +33,7 @@ function Get-OSRepoAvailableVersions
     [OutputType('String')]
     param (
         [Parameter(Mandatory = $true)]
-        [ValidateSet('PlatformServer', 'ServiceStudio')]
+        [ValidateSet('PlatformServer', 'ServiceStudio', 'Lifetime')]
         [string]$Application,
 
         [Parameter(Mandatory = $true)]
@@ -65,6 +76,10 @@ function Get-OSRepoAvailableVersions
             'ServiceStudio'
             {
                 $versions = $files -replace 'DevelopmentEnvironment-', '' -replace '.exe',''
+            }
+            'Lifetime'
+            {
+                $versions = $files -replace 'LifeTimeWithPlatformServer-', '' -replace '.exe',''
             }
         }
 

--- a/src/Outsystems.SetupTools/Functions/Install-OSServer.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServer.ps1
@@ -44,13 +44,16 @@ function Install-OSServer
     param(
         [Parameter(ParameterSetName = 'Local')]
         [Parameter(ParameterSetName = 'Remote')]
+        [ValidateNotNullOrEmpty()]
         [string]$InstallDir = $OSDefaultInstallDir,
 
         [Parameter(ParameterSetName = 'Local', Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [string]$SourcePath,
 
         [Parameter(ParameterSetName = 'Local', Mandatory = $true)]
         [Parameter(ParameterSetName = 'Remote', Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [version]$Version,
 
         [Parameter()]

--- a/src/Outsystems.SetupTools/Functions/Install-OSServer.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServer.ps1
@@ -57,7 +57,10 @@ function Install-OSServer
         [version]$Version,
 
         [Parameter()]
-        [switch]$SkipRabbitMQ
+        [switch]$SkipRabbitMQ,
+
+        [Parameter()]
+        [switch]$WithLifetime
     )
 
     begin
@@ -76,6 +79,14 @@ function Install-OSServer
 
         $osVersion = GetServerVersion
         $osInstallDir = GetServerInstallDir
+
+        # Installer name
+        $osInstaller = "PlatformServer-$Version.exe"
+        if ($WithLifetime.IsPresent)
+        {
+            # Lifetime installer instead
+            $osInstaller = "LifeTimeWithPlatformServer-$Version.exe"
+        }
     }
 
     process
@@ -170,12 +181,12 @@ function Install-OSServer
                 {
                     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "SourcePath not specified. Downloading installer from repository"
 
-                    $installer = "$ENV:TEMP\PlatformServer-$Version.exe"
+                    $installer = "$ENV:TEMP\$osInstaller"
                     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Saving installer to $installer"
 
                     try
                     {
-                        DownloadOSSources -URL "$OSRepoURL\PlatformServer-$Version.exe" -SavePath $installer
+                        DownloadOSSources -URL "$OSRepoURL\$osInstaller" -SavePath $installer
                     }
                     catch
                     {
@@ -192,7 +203,7 @@ function Install-OSServer
                 "Local"
                 {
                     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "SourcePath specified. Using the local installer"
-                    $installer = "$SourcePath\PlatformServer-$Version.exe"
+                    $installer = "$SourcePath\$osInstaller"
                 }
             }
 

--- a/src/Outsystems.SetupTools/Functions/Install-OSServer.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServer.ps1
@@ -20,6 +20,9 @@ function Install-OSServer
     .PARAMETER Version
     The version to be installed.
 
+    .PARAMETER WithLifetime
+    If specified, the cmdlet will install the platform server with lifetime.
+
     .EXAMPLE
     Install-OSServer -Version "10.0.823.0"
 

--- a/src/Outsystems.SetupTools/Functions/Install-OSServiceStudio.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServiceStudio.ps1
@@ -34,13 +34,16 @@ function Install-OSServiceStudio
     param(
         [Parameter(ParameterSetName = 'Local')]
         [Parameter(ParameterSetName = 'Remote')]
+        [ValidateNotNullOrEmpty()]
         [string]$InstallDir = $OSDefaultInstallDir,
 
         [Parameter(ParameterSetName = 'Local', Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [string]$SourcePath,
 
         [Parameter(ParameterSetName = 'Local', Mandatory = $true)]
         [Parameter(ParameterSetName = 'Remote', Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [string]$Version
     )
 

--- a/test/unit/Install-OSServer.Tests.ps1
+++ b/test/unit/Install-OSServer.Tests.ps1
@@ -178,5 +178,17 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             Mock IsAdmin { return $false }
             It 'Should throw an exception' { { Install-OSServer -Version '10.0.0.1' -ErrorAction Stop } | Should throw }
         }
+
+        Context 'When lifetime switch is specified' {
+
+            Mock GetServerVersion { return $null }
+            Mock GetServerInstallDir { return $null }
+
+            $assRunParams = @{ 'CommandName' = 'Start-Process'; 'Times' = 1; 'Exactly' = $true; 'Scope' = 'Context'; 'ParameterFilter' = { $FilePath -eq "$ENV:TEMP\LifeTimeWithPlatformServer-11.0.0.1.exe" } }
+
+            $result = Install-OSServer -Version '11.0.0.1' -WithLifeTime -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should run the installation using the lifetime installer' { Assert-MockCalled @assRunParams }
+        }
     }
 }

--- a/test/unit/Install-OSServer.Tests.ps1
+++ b/test/unit/Install-OSServer.Tests.ps1
@@ -190,5 +190,17 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
             It 'Should run the installation using the lifetime installer' { Assert-MockCalled @assRunParams }
         }
+
+        Context 'When lifetime switch is NOT specified' {
+
+            Mock GetServerVersion { return $null }
+            Mock GetServerInstallDir { return $null }
+
+            $assRunParams = @{ 'CommandName' = 'Start-Process'; 'Times' = 1; 'Exactly' = $true; 'Scope' = 'Context'; 'ParameterFilter' = { $FilePath -eq "$ENV:TEMP\PlatformServer-11.0.0.1.exe" } }
+
+            $result = Install-OSServer -Version '11.0.0.1' -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should run the installation using the normal installer' { Assert-MockCalled @assRunParams }
+        }
     }
 }


### PR DESCRIPTION
- Updated Get-OSRepoAvailableVersions to support the new lifetime installer.
- Updated Install-OSServer. Added the parameter -WithLifetime that when specified the CmdLet will use the new Lifetime installer.
- Fixed Install-OSServiceStudio. Now throws if an empty/null -InstallDir, -SourcePath and -Version parameters is specified.
- Fixed Install-OSServer. Now throws if an empty/null -InstallDir, -SourcePath and -Version parameters is specified.
- Closes #42 
 