### PR TITLE
Fixed issue on internal function GetServiceStudioInstallDir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Outsystems.SetupTools Release History
 
+## 2.5.1.0
+
+### Changes
+
+- Fixed internal function regarding service studio installation. Was throwing an error when service studio was not installed
+
 ## 2.5.0.0
 
 ### Changes

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.5.0.{build}
+version: 2.5.1.{build}
 
 only_commits:
   files:

--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -427,8 +427,12 @@ function GetServiceStudioInstallDir([string]$MajorVersion)
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Getting the contents of the registry key HKLM:SOFTWARE\OutSystems\Installer\Service Studio $MajorVersion\(default)"
     $output = RegRead -Path "HKLM:SOFTWARE\OutSystems\Installer\Service Studio $MajorVersion" -Name "(default)"
 
-    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Returning $output"
+    if ($output)
+    {
+        $output = $output.Replace("\Service Studio", "")
+    }
 
+    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Returning $output"
     return $output.Replace("\Service Studio", "")
 }
 

--- a/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
+++ b/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
@@ -12,7 +12,7 @@
 RootModule = 'OutSystems.SetupTools.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.5.0.0'
+ModuleVersion = '2.5.1.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
- Bug introduced in the last version 2.5.0.0.
- GetServiceStudioInstallDir was throwing an error when the service studio was not installed.