### PR TITLE
New function Write-OSInstallLog and small improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - New function Write-OSInstallLog. To write messages on the install log and the verbose stream
 - Install-OSServer. Added -FullPathInstallDir switch
+- Changed FullPathInstallDir parameter on Install-OSServer and Install-OSServiceStudio to dynamic. Only available when InstallDir parameter is specified
 
 ## 2.5.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Outsystems.SetupTools Release History
 
+## 2.6.0.0
+
+### Changes
+
+- New function Write-OSInstallLog. To write messages on the install log and the verbose stream
+- Install-OSServer. Added -FullPathInstallDir switch
+
 ## 2.5.3.0
 
 ### Changes

--- a/src/Outsystems.SetupTools/Functions/Install-OSServer.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServer.ps1
@@ -67,11 +67,26 @@ function Install-OSServer
         [switch]$SkipRabbitMQ,
 
         [Parameter()]
-        [switch]$WithLifetime,
-
-        [ValidateNotNullOrEmpty()]
-        [switch]$FullPathInstallDir
+        [switch]$WithLifetime
     )
+
+    dynamicParam
+    {
+        $paramDictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+
+        if ($InstallDir)
+        {
+            $FullPathInstallDirAttrib = New-Object System.Management.Automation.ParameterAttribute
+            $FullPathInstallDirAttribCollection = New-Object System.Collections.ObjectModel.Collection[System.Attribute]
+            $FullPathInstallDirAttribCollection.Add($FullPathInstallDirAttrib)
+            $FullPathInstallDirAttribCollection.Add($(New-Object Management.Automation.ValidateNotNullOrEmptyAttribute))
+            $FullPathInstallDirParam = New-Object System.Management.Automation.RuntimeDefinedParameter('FullPathInstallDir', [switch], $FullPathInstallDirAttribCollection)
+
+            $paramDictionary.Add('FullPathInstallDir', $FullPathInstallDirParam)
+        }
+
+        return $paramDictionary
+    }
 
     begin
     {
@@ -119,7 +134,7 @@ function Install-OSServer
             LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "OutSystems platform server is not installed"
             LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Proceeding with normal installation"
 
-            if (-not $FullPathInstallDir.IsPresent)
+            if (-not $PSBoundParameters.FullPathInstallDir.IsPresent)
             {
                 $InstallDir = "$InstallDir\Platform Server"
             }

--- a/src/Outsystems.SetupTools/Functions/Install-OSServer.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServer.ps1
@@ -23,6 +23,9 @@ function Install-OSServer
     .PARAMETER WithLifetime
     If specified, the cmdlet will install the platform server with lifetime.
 
+    .PARAMETER FullPathInstallDir
+    If specified, the InstallDir will not be appended with \Platform Server
+
     .EXAMPLE
     Install-OSServer -Version "10.0.823.0"
 
@@ -33,7 +36,7 @@ function Install-OSServer
     Install-OSServer -Version "10.0.823.0" -InstallDir D:\Outsystems -SourcePath c:\temp
 
     .EXAMPLE
-    Install-OSServer -Version "11.0.108.0" -InstallDir D:\Outsystems -SourcePath c:\temp -SkipRabbitMQ
+    Install-OSServer -Version "11.0.108.0" -InstallDir 'D:\Outsystems\Platform Server' -SourcePath c:\temp -SkipRabbitMQ -FullPathInstallDir
 
     .EXAMPLE
     To install the latest 11.0 version
@@ -64,7 +67,10 @@ function Install-OSServer
         [switch]$SkipRabbitMQ,
 
         [Parameter()]
-        [switch]$WithLifetime
+        [switch]$WithLifetime,
+
+        [ValidateNotNullOrEmpty()]
+        [switch]$FullPathInstallDir
     )
 
     begin
@@ -112,7 +118,15 @@ function Install-OSServer
         {
             LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "OutSystems platform server is not installed"
             LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Proceeding with normal installation"
-            $InstallDir = "$InstallDir\Platform Server"
+
+            if (-not $FullPathInstallDir.IsPresent)
+            {
+                $InstallDir = "$InstallDir\Platform Server"
+            }
+            else
+            {
+                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "FullPathInstallDir specified. Not appending \Platform Server"
+            }
             $installPlatformServer = $true
         }
         elseif ([version]$osVersion -lt [version]$Version)
@@ -214,7 +228,7 @@ function Install-OSServer
             try
             {
                 LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Starting the installation. This can take a while..."
-                $result = Start-Process -FilePath $installer -ArgumentList "/S", "/D=$InstallDir" -Wait -PassThru -ErrorAction Stop
+                $result = Start-Process -FilePath $installer -ArgumentList "/S /D=$InstallDir" -Wait -PassThru -ErrorAction Stop
                 $exitCode = $result.ExitCode
             }
             catch

--- a/src/Outsystems.SetupTools/Functions/Install-OSServiceStudio.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServiceStudio.ps1
@@ -51,13 +51,26 @@ function Install-OSServiceStudio
         [Parameter(ParameterSetName = 'Local', Mandatory = $true)]
         [Parameter(ParameterSetName = 'Remote', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$Version,
-
-        [Parameter(ParameterSetName = 'Local')]
-        [Parameter(ParameterSetName = 'Remote')]
-        [ValidateNotNullOrEmpty()]
-        [switch]$FullPathInstallDir
+        [string]$Version
     )
+
+    dynamicParam
+    {
+        $paramDictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+
+        if ($InstallDir)
+        {
+            $FullPathInstallDirAttrib = New-Object System.Management.Automation.ParameterAttribute
+            $FullPathInstallDirAttribCollection = New-Object System.Collections.ObjectModel.Collection[System.Attribute]
+            $FullPathInstallDirAttribCollection.Add($FullPathInstallDirAttrib)
+            $FullPathInstallDirAttribCollection.Add($(New-Object Management.Automation.ValidateNotNullOrEmptyAttribute))
+            $FullPathInstallDirParam = New-Object System.Management.Automation.RuntimeDefinedParameter('FullPathInstallDir', [switch], $FullPathInstallDirAttribCollection)
+
+            $paramDictionary.Add('FullPathInstallDir', $FullPathInstallDirParam)
+        }
+
+        return $paramDictionary
+    }
 
     begin
     {
@@ -97,7 +110,7 @@ function Install-OSServiceStudio
             LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Outsystems service studio is not installed"
             LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Proceeding with normal installation"
 
-            if (-not $FullPathInstallDir.IsPresent)
+            if (-not $PSBoundParameters.FullPathInstallDir.IsPresent)
             {
                 $InstallDir = "$InstallDir\Development Environment $(([System.Version]$Version).Major).$(([System.Version]$Version).Minor)"
             }

--- a/src/Outsystems.SetupTools/Functions/Set-OSInstallLog.ps1
+++ b/src/Outsystems.SetupTools/Functions/Set-OSInstallLog.ps1
@@ -17,7 +17,7 @@ function Set-OSInstallLog
     The log filename.
 
     .PARAMETER LogDebug
-    Logs the debug stream
+    Writes on the log the debug stream
 
     .EXAMPLE
     Set-OSInstallLog -Path $ENV:Windir\temp -File Install.log -LogDebug

--- a/src/Outsystems.SetupTools/Functions/Write-OSInstallLog.ps1
+++ b/src/Outsystems.SetupTools/Functions/Write-OSInstallLog.ps1
@@ -1,0 +1,39 @@
+function Write-OSInstallLog
+{
+    <#
+    .SYNOPSIS
+    Writes a message on the log file and on the verbose stream.
+
+    .DESCRIPTION
+    This will Write a message on the log file and on the verbose stream.
+
+    .PARAMETER LogDebug
+    Writes on the log the debug stream
+
+    .EXAMPLE
+    Write-OSInstallLog -Message 'My Message'
+
+    #>
+
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Message
+    )
+
+    begin
+    {
+        SendFunctionStartEvent -InvocationInfo $MyInvocation
+    }
+
+    process
+    {
+        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message $Message
+    }
+
+    end
+    {
+        SendFunctionEndEvent -InvocationInfo $MyInvocation
+    }
+}

--- a/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
+++ b/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
@@ -111,7 +111,8 @@ FunctionsToExport = @(
     'Get-OSServerInfo',
     'Get-OSServiceStudioInfo',
     'Get-OSPlatformDeploymentZone',
-    'Set-OSPlatformDeploymentZone'
+    'Set-OSPlatformDeploymentZone',
+    'Write-OSInstallLog'
 )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/test/unit/Install-OSServer.Tests.ps1
+++ b/test/unit/Install-OSServer.Tests.ps1
@@ -123,7 +123,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
             $assRunParams = @{ 'CommandName' = 'Start-Process'; 'Times' = 1; 'Exactly' = $true; 'Scope' = 'Context'; 'ParameterFilter' = { $ArgumentList -eq "/S /D=C:\Program Files\Outsystems" } }
 
-            $result = Install-OSServer -Version '10.0.0.1' -FullPathInstallDir -ErrorVariable err -ErrorAction SilentlyContinue
+            $result = Install-OSServer -Version '10.0.0.1' -InstallDir 'C:\Program Files\Outsystems' -FullPathInstallDir -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the installation' { Assert-MockCalled @assRunParams }
             It 'Should return the right result' {

--- a/test/unit/Install-OSServer.Tests.ps1
+++ b/test/unit/Install-OSServer.Tests.ps1
@@ -116,6 +116,26 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not throw' { { Install-OSServer -Version '10.0.0.1' -ErrorAction SilentlyContinue } | Should Not throw }
         }
 
+        Context 'When the platform server is not installed and -FullPathInstallDir is specified' {
+
+            Mock GetServerVersion { return $null }
+            Mock GetServerInstallDir { return $null }
+
+            $assRunParams = @{ 'CommandName' = 'Start-Process'; 'Times' = 1; 'Exactly' = $true; 'Scope' = 'Context'; 'ParameterFilter' = { $ArgumentList -eq "/S /D=C:\Program Files\Outsystems" } }
+
+            $result = Install-OSServer -Version '10.0.0.1' -FullPathInstallDir -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should run the installation' { Assert-MockCalled @assRunParams }
+            It 'Should return the right result' {
+                $result.Success | Should Be $true
+                $result.RebootNeeded | Should Be $false
+                $result.ExitCode | Should Be 0
+                $result.Message | Should Be 'Outsystems platform server successfully installed'
+            }
+            It 'Should not output an error' { $err.Count | Should Be 0 }
+            It 'Should not throw' { { Install-OSServer -Version '10.0.0.1' -ErrorAction SilentlyContinue } | Should Not throw }
+        }
+
         Context 'When the platform installer returns an error' {
 
             Mock GetServerVersion { return $null }

--- a/test/unit/Install-OSServiceStudio.Tests.ps1
+++ b/test/unit/Install-OSServiceStudio.Tests.ps1
@@ -125,7 +125,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
             $assRunParams = @{ 'CommandName' = 'Start-Process'; 'Times' = 1; 'Exactly' = $true; 'Scope' = 'Context'; 'ParameterFilter' = { $ArgumentList -eq "/S /D=C:\Program Files\Outsystems" } }
 
-            $result = Install-OSServiceStudio -Version '10.0.0.1' -FullPathInstallDir -ErrorVariable err -ErrorAction SilentlyContinue
+            $result = Install-OSServiceStudio -Version '10.0.0.1' -InstallDir 'C:\Program Files\Outsystems' -FullPathInstallDir -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the installation' { Assert-MockCalled @assRunParams }
             It 'Should return the right result' {


### PR DESCRIPTION
- New function Write-OSInstallLog. To write messages on the install log and the verbose stream
- Install-OSServer. Added -FullPathInstallDir switch
- Changed FullPathInstallDir parameter on Install-OSServer and Install-OSServiceStudio to dynamic. Only available when InstallDir parameter is specified