### PR TITLE
Fix inability to deploy Lifetime after Platform Server upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Outsystems.SetupTools Release History
 
+## 3.7.1.0
+
+- Publish-OSPlatformLifetime: Allowed to run after a Platform Server upgrade
+
 ## 3.7.0.0
 
 - Set-OSServerConfig: Added SectionAttribute and SectionAttributeValue parameters

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.7.0.{build}
+version: 3.7.1.{build}
 
 only_commits:
   files:

--- a/src/Outsystems.SetupTools/Functions/Publish-OSPlatformLifetime.ps1
+++ b/src/Outsystems.SetupTools/Functions/Publish-OSPlatformLifetime.ps1
@@ -117,18 +117,6 @@ function Publish-OSPlatformLifetime
             return $installResult
         }
 
-        if ($(GetSysComponentsCompiledVersion) -ne $osVersion)
-        {
-            LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 3 -Message "System Components version mismatch. You should run the Publish-OSPlatformSystemComponents first"
-            WriteNonTerminalError -Message "System Components version mismatch. You should run the Publish-OSPlatformSystemComponents first"
-
-            $installResult.Success = $false
-            $installResult.ExitCode = -1
-            $installResult.Message = 'System Components version mismatch. You should run the Publish-OSPlatformSystemComponents first'
-
-            return $installResult
-        }
-
         if ($(GetLifetimeCompiledVersion) -ne $osVersion)
         {
             $doInstall = $true

--- a/src/Outsystems.SetupTools/Functions/Set-OSServerConfig.ps1
+++ b/src/Outsystems.SetupTools/Functions/Set-OSServerConfig.ps1
@@ -444,7 +444,7 @@ function Set-OSServerConfig
                     return $null
                 }
 
-                if ($PSBoundParameters.InstallServiceCenter.IsPresent)
+                if ($PSBoundParameters.InstallServiceCenter.IsPresent -or $PSBoundParameters.UpgradeEnvironment.IsPresent)
                 {
                     # Flag service center installation
                     try

--- a/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
+++ b/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
@@ -12,7 +12,7 @@
 RootModule = 'OutSystems.SetupTools.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.7.0.0'
+ModuleVersion = '3.7.1.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/test/unit/Publish-OSPlatformLifetime.Tests.ps1
+++ b/test/unit/Publish-OSPlatformLifetime.Tests.ps1
@@ -51,23 +51,6 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not throw' { { Publish-OSPlatformLifetime -ErrorAction SilentlyContinue } | Should Not throw }
         }
 
-        Context 'When system components are not installed or have a wrong version' {
-
-            Mock GetSysComponentsCompiledVersion { return $null }
-
-            $result = Publish-OSPlatformLifetime -ErrorVariable err -ErrorAction SilentlyContinue
-
-            It 'Should not run the installation' { Assert-MockCalled @assNotRunPublishSolution}
-            It 'Should return the right result' {
-                $result.Success | Should Be $false
-                $result.RebootNeeded | Should Be $false
-                $result.ExitCode | Should Be -1
-                $result.Message | Should Be 'System Components version mismatch. You should run the Publish-OSPlatformSystemComponents first'
-            }
-            It 'Should output an error' { $err[-1] | Should Be 'System Components version mismatch. You should run the Publish-OSPlatformSystemComponents first' }
-            It 'Should not throw' { { Publish-OSPlatformLifetime -ErrorAction SilentlyContinue } | Should Not throw }
-        }
-
         Context 'When lifetime and the platform dont have the same version' {
 
             Mock GetLifetimeCompiledVersion { return '10.0.0.0' }


### PR DESCRIPTION
When using the command
`Publish-OSPlatformLifetime`
after a 
`Set-OSServerConfig -Apply -UpgradeEnvironment`
we get the error 
> Service Center version mismatch. You should run the Install-OSPlatformServiceCenter first

I believe we would also get this
> System Components version mismatch. You should run the Publish-OSPlatformSystemComponents first

For current Platform Server versions, **-UpgradeEnvironment** publishes both the Service Center and System Components, making these 2 extra commands unnecessary and time consuming.

This PR is expected to solve both of these issues.