### PR TITLE
#RPST-1230 Change SetOSServerConfig to allow properties with numbers

### DIFF
--- a/src/Outsystems.SetupTools/Functions/Set-OSServerConfig.ps1
+++ b/src/Outsystems.SetupTools/Functions/Set-OSServerConfig.ps1
@@ -84,7 +84,7 @@ function Set-OSServerConfig
     param(
         [Parameter(ParameterSetName = 'ChangeSettings', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [ValidatePattern('^[a-zA-Z]+$')]
+        [ValidatePattern('^[a-zA-Z0-9]+$')]
         [string]$SettingSection,
 
         [Parameter(ValueFromPipeline = $true, ParameterSetName = 'ChangeSettings')]
@@ -97,7 +97,7 @@ function Set-OSServerConfig
 
         [Parameter(ParameterSetName = 'ChangeSettings', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [ValidatePattern('^[a-zA-Z_]+$')]
+        [ValidatePattern('^[a-zA-Z0-9]+$')]
         [string]$Setting,
 
         [Parameter(ValueFromPipeline = $true, ParameterSetName = 'ChangeSettings', Mandatory = $true)]


### PR DESCRIPTION
Change SetOSServerConfig regex expression to allow properties with numbers. Motif: new configurations are going to be added to server.hsconf which are named with numbers (e.g. 'S3AccessKey')