### PR TITLE
R11PIT-160 - Upgrade .Net Core 3.1 Platform Prerequisites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Outsystems.SetupTools Release History
 
+## 3.12.0.0
+
+- Updated .NET Core to 3.1.14
+
 ## 3.11.1.0
 
 - Fix Set-OSServerConfig and Get-OSServerConfig bug introduced in 3.11.0.0 version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.11.1.{build}
+version: 3.12.0.{build}
 
 only_commits:
   files:

--- a/src/Outsystems.SetupTools/Lib/Constants.ps1
+++ b/src/Outsystems.SetupTools/Lib/Constants.ps1
@@ -39,7 +39,7 @@ $OS11ReqsMinOSVersion = "10.0.14393"
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
 $OSReqsMinOSProductType = 2
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
-$OS11ReqsMinDotNetCoreVersion = "2.1.11"
+$OS11ReqsMinDotNetCoreVersion = "3.1.14"
 
 # Microsoft Build Tools 2015 MSI Product Codes
 
@@ -91,7 +91,7 @@ $OSRepoURL = "https://ossetuptools.blob.core.windows.net/sources"
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
 $OSRepoURLBuildTools = 'https://download.microsoft.com/download/E/E/D/EEDF18A8-4AED-4CE0-BEBE-70A83094FC5A/BuildTools_Full.exe'
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
-$OSRepoURLDotNETCore = 'https://download.visualstudio.microsoft.com/download/pr/eebd54bc-c3a2-4580-bb29-b35c1c5ffa92/22ffe5649861167d3d5728d3cb4b10a1/dotnet-hosting-2.1.12-win.exe'
+$OSRepoURLDotNETCore = 'https://download.visualstudio.microsoft.com/download/pr/bdc70151-74f7-427c-a368-716d5f1840c5/6186889f6c784bae224eb15fb94c45fe/dotnet-hosting-3.1.14-win.exe'
 
 # .NET related
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]

--- a/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
+++ b/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
@@ -12,7 +12,7 @@
 RootModule = 'OutSystems.SetupTools.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.11.1.0'
+ModuleVersion = '3.12.0.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/test/unit/Install-OSServerPreReqs.Tests.ps1
+++ b/test/unit/Install-OSServerPreReqs.Tests.ps1
@@ -115,7 +115,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
             Mock GetMSBuildToolsInstallInfo { return @{ 'HasMSBuild2015' = $True; 'HasMSBuild2017' = $False; 'LatestVersionInstalled' = 'MS Build Tools 2015'; 'RebootNeeded' = $False } }
             Mock GetDotNet4Version { return 461808 }
-            Mock GetWindowsServerHostingVersion { return '2.1.12' }
+            Mock GetWindowsServerHostingVersion { return '3.1.14' }
 
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
@@ -165,7 +165,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
             Mock GetMSBuildToolsInstallInfo { return @{ 'HasMSBuild2015' = $True; 'HasMSBuild2017' = $False; 'LatestVersionInstalled' = 'MS Build Tools 2015'; 'RebootNeeded' = $False } }
             Mock GetDotNet4Version { return 461808 }
-            Mock GetWindowsServerHostingVersion { return '2.1.12' }
+            Mock GetWindowsServerHostingVersion { return '3.1.14' }
 
             $result = Install-OSServerPreReqs -MajorVersion '12' -ErrorVariable err -ErrorAction SilentlyContinue
 

--- a/test/unit/Lib.Constants.Tests.ps1
+++ b/test/unit/Lib.Constants.Tests.ps1
@@ -51,7 +51,7 @@ Describe 'Lib Constants Tests' {
     Context 'Check .NETCore constants' {
 
         $SavePath = "$env:TEMP\dotnetcore.exe"
-        $FileHash = 'AC74CADB690D3A5A175CEDD0EF02A11ABE41A292F9C9055B28522E3EB7B02726'
+        $FileHash = '187179215D0C9DE82F6C6F005E08AC517E34E9689959964053B0F60FEDFD8302'
 
         It 'Should be downloadable and have the right file hash' {
             (New-Object System.Net.WebClient).DownloadFile($OSRepoURLDotNETCore, $SavePath)


### PR DESCRIPTION
Change the value of MinDotNetCoreVersion to 3.1.14 and modify pointer to .Net hosting bundle installer to use the installer of version 3.1.14

More context about these changes can be found [here](https://outsystemsrd.atlassian.net/browse/R11PIT-160)!