### PR TITLE
R11PIT-159: Install both .NET Core versions in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Outsystems.SetupTools Release History
 
+## 3.13.0.0
+
+- Updated Install-OSServerPreReqs. Now installs .NET Core hosting bundle version 3.1.14 and 2.1.12. The new .NET Core version is a pre-req of newer OutSystems 11 versions. To maintain compability we decided to install both versions.
+
 ## 3.12.0.0
 
 - Updated .NET Core to 3.1.14

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.12.0.{build}
+version: 3.13.0.{build}
 
 only_commits:
   files:

--- a/examples/DeployOnPrem/CreateOfflineBundle.ps1
+++ b/examples/DeployOnPrem/CreateOfflineBundle.ps1
@@ -10,7 +10,8 @@ Write-Verbose "Starting. Please wait..." -Verbose
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $OSRepoURLDotNET = 'https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe'
 $OSRepoURLBuildTools = 'https://download.microsoft.com/download/E/E/D/EEDF18A8-4AED-4CE0-BEBE-70A83094FC5A/BuildTools_Full.exe'
-$OSRepoURLDotNETCore = 'https://download.visualstudio.microsoft.com/download/pr/0ad9d7d3-3cca-48e8-a5cc-07a5a6b8a020/820fd44b4eca9f31b11875d75068bb74/dotnet-hosting-2.1.11-win.exe'
+$OSRepoURLDotNETCore = 'https://download.visualstudio.microsoft.com/download/pr/bdc70151-74f7-427c-a368-716d5f1840c5/6186889f6c784bae224eb15fb94c45fe/dotnet-hosting-3.1.14-win.exe'
+$OSRepoURLDotNETCore21 = 'https://download.visualstudio.microsoft.com/download/pr/eebd54bc-c3a2-4580-bb29-b35c1c5ffa92/22ffe5649861167d3d5728d3cb4b10a1/dotnet-hosting-2.1.12-win.exe'
 $OSRepoURL = 'https://myfilerepo.blob.core.windows.net/sources'
 $OSServerVersion = ""
 $OSServiceStudioVersion = ""
@@ -39,7 +40,9 @@ Write-Verbose "Downloading .NET 4.7.2" -Verbose
 (New-Object System.Net.WebClient).DownloadFile($OSRepoURLDotNET, "$env:Temp\OSOfflineBundle\PreReqs\DotNet.exe")
 Write-Verbose "Downloading BuildTools 2015" -Verbose
 (New-Object System.Net.WebClient).DownloadFile($OSRepoURLBuildTools, "$env:Temp\OSOfflineBundle\PreReqs\BuildTools_Full.exe")
-Write-Verbose "Downloading .NET Core 2.0.8" -Verbose
+Write-Verbose "Downloading .NET Core 2.1 Windows Server Hosting bundle" -Verbose
+(New-Object System.Net.WebClient).DownloadFile($OSRepoURLDotNETCore21, "$env:Temp\OSOfflineBundle\PreReqs\DotNetCore_WindowsHosting21.exe")
+Write-Verbose "Downloading .NET Core 3.1 Windows Server Hosting bundle" -Verbose
 (New-Object System.Net.WebClient).DownloadFile($OSRepoURLDotNETCore, "$env:Temp\OSOfflineBundle\PreReqs\DotNetCore_WindowsHosting.exe")
 
 # -- Download outsystems

--- a/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
@@ -147,7 +147,7 @@ function Get-OSServerPreReqs
                 $RequirementStatuses += CreateRequirementStatus -Title ".NET Core Windows Server Hosting" `
                                                                 -ScriptBlock `
                                                                 {
-                                                                    $Status = $([version]$(GetWindowsServerHostingVersion) -ge [version]$OS11ReqsMinDotNetCoreVersion)
+                                                                    $Status = $([version](GetDotNetCoreHostingBundleVersions | Select-Object -First 1) -ge [version]$script:OSDotNetCoreHostingBundleReq['3']['Version'])
                                                                     $OKMessages = @("Minimum .NET Core Windows Server Hosting found.")
                                                                     $NOKMessages = @("Minimum .NET Core Windows Server Hosting not found.")
                                                                     $IISStatus = $True

--- a/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
@@ -128,18 +128,24 @@ function Install-OSServerPreReqs
             default
             {
                 # Check .NET Core Windows Server Hosting version
+                $installDotNetCoreHostingBundle2 = $true
+                $installDotNetCoreHostingBundle3 = $true
                 foreach ($version in GetDotNetCoreHostingBundleVersions)
                 {
                     # Check version 2.1
-                    if (-not (([version]$version).Major -eq 2 -and ([version]$version) -gt [version]$script:OSDotNetCoreHostingBundleReq['2']['Version'])) {
-                        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Minimum .NET Core Windows Server Hosting version 2.1 for OutSystems $MajorVersion not found. We will try to download and install the latest .NET Core Windows Server Hosting bundle"
-                        $installDotNetCoreHostingBundle2 = $true
+                    if (([version]$version).Major -eq 2 -and ([version]$version) -ge [version]$script:OSDotNetCoreHostingBundleReq['2']['Version']) {
+                        $installDotNetCoreHostingBundle2 = $false
                     }
                     # Check version 3.1
-                    if (-not (([version]$version).Major -eq 3 -and ([version]$version) -gt [version]$script:OSDotNetCoreHostingBundleReq['3']['Version'])) {
-                        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Minimum .NET Core Windows Server Hosting version 3.1 for OutSystems $MajorVersion not found. We will try to download and install the latest .NET Core Windows Server Hosting bundle"
-                        $installDotNetCoreHostingBundle3 = $true
+                    if (([version]$version).Major -eq 3 -and ([version]$version) -ge [version]$script:OSDotNetCoreHostingBundleReq['3']['Version']) {
+                        $installDotNetCoreHostingBundle3 = $false
                     }
+                }
+                if ($installDotNetCoreHostingBundle2) {
+                    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Minimum .NET Core Windows Server Hosting version 2.1 for OutSystems $MajorVersion not found. We will try to download and install the latest .NET Core Windows Server Hosting bundle"
+                }
+                if ($installDotNetCoreHostingBundle3) {
+                    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Minimum .NET Core Windows Server Hosting version 3.1 for OutSystems $MajorVersion not found. We will try to download and install the latest .NET Core Windows Server Hosting bundle"
                 }
             }
         }

--- a/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
@@ -128,14 +128,18 @@ function Install-OSServerPreReqs
             default
             {
                 # Check .NET Core Windows Server Hosting version
-                if ([version]$(GetWindowsServerHostingVersion) -lt [version]$OS11ReqsMinDotNetCoreVersion)
+                foreach ($version in GetDotNetCoreHostingBundleVersions)
                 {
-                    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Minimum .NET Core Windows Server Hosting version for OutSystems $MajorVersion not found. We will try to download and install the latest .NET Core Windows Server Hosting bundle"
-                    $installDotNetCore = $true
-                }
-                else
-                {
-                    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Minimum .NET Core Windows Server Hosting for OutSystems $MajorVersion found"
+                    # Check version 2.1
+                    if (-not (([version]$version).Major -eq 2 -and ([version]$version) -gt [version]$script:OSDotNetCoreHostingBundleReq['2']['Version'])) {
+                        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Minimum .NET Core Windows Server Hosting version 2.1 for OutSystems $MajorVersion not found. We will try to download and install the latest .NET Core Windows Server Hosting bundle"
+                        $installDotNetCoreHostingBundle2 = $true
+                    }
+                    # Check version 3.1
+                    if (-not (([version]$version).Major -eq 3 -and ([version]$version) -gt [version]$script:OSDotNetCoreHostingBundleReq['3']['Version'])) {
+                        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Minimum .NET Core Windows Server Hosting version 3.1 for OutSystems $MajorVersion not found. We will try to download and install the latest .NET Core Windows Server Hosting bundle"
+                        $installDotNetCoreHostingBundle3 = $true
+                    }
                 }
             }
         }
@@ -256,14 +260,13 @@ function Install-OSServerPreReqs
             }
         }
 
-        # Install .NET Core Windows Server Hosting bundle
-        if ($installDotNetCore)
+        # Install .NET Core Windows Server Hosting bundle version 2.1
+        if ($installDotNetCoreHostingBundle2)
         {
-            # Install version 2.1
             try
             {
                 LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Installing .NET Core 2.1 Windows Server Hosting bundle"
-                $exitCode = InstallDotNetCore21 -Sources $SourcePath
+                $exitCode = InstallDotNetCoreHostingBundle -MajorVersion '2' -Sources $SourcePath
             }
             catch [System.IO.FileNotFoundException]
             {
@@ -314,11 +317,15 @@ function Install-OSServerPreReqs
                 }
             }
 
-            # Install version 3.1
+        }
+
+        # Install .NET Core Windows Server Hosting bundle version 3.1
+        if ($installDotNetCoreHostingBundle3)
+        {
             try
             {
                 LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Installing .NET Core 3.1 Windows Server Hosting bundle"
-                $exitCode = InstallDotNetCore -Sources $SourcePath
+                $exitCode = InstallDotNetCoreHostingBundle -MajorVersion '3' -Sources $SourcePath
             }
             catch [System.IO.FileNotFoundException]
             {

--- a/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
@@ -259,30 +259,31 @@ function Install-OSServerPreReqs
         # Install .NET Core Windows Server Hosting bundle
         if ($installDotNetCore)
         {
+            # Install version 2.1
             try
             {
-                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Installing .NET Core Windows Server Hosting bundle"
-                $exitCode = InstallDotNetCore -Sources $SourcePath
+                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Installing .NET Core 2.1 Windows Server Hosting bundle"
+                $exitCode = InstallDotNetCore21 -Sources $SourcePath
             }
             catch [System.IO.FileNotFoundException]
             {
-                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Exception $_.Exception -Stream 3 -Message ".NET Core installer not found"
-                WriteNonTerminalError -Message ".NET Core installer not found"
+                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Exception $_.Exception -Stream 3 -Message ".NET Core 2.1 installer not found"
+                WriteNonTerminalError -Message ".NET Core 2.1 installer not found"
 
                 $installResult.Success = $false
                 $installResult.ExitCode = -1
-                $installResult.Message = '.NET Core installer not found'
+                $installResult.Message = '.NET Core 2.1 installer not found'
 
                 return $installResult
             }
             catch
             {
-                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Exception $_.Exception -Stream 3 -Message "Error downloading or starting the .NET Core installation"
-                WriteNonTerminalError -Message "Error downloading or starting the .NET Core installation"
+                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Exception $_.Exception -Stream 3 -Message "Error downloading or starting the .NET Core 2.1 installation"
+                WriteNonTerminalError -Message "Error downloading or starting the .NET Core 2.1 installation"
 
                 $installResult.Success = $false
                 $installResult.ExitCode = -1
-                $installResult.Message = 'Error downloading or starting the .NET Core installation'
+                $installResult.Message = 'Error downloading or starting the .NET Core 2.1 installation'
 
                 return $installResult
             }
@@ -291,23 +292,78 @@ function Install-OSServerPreReqs
             {
                 0
                 {
-                    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message ".NET Core Windows Server Hosting bundle successfully installed."
+                    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message ".NET Core 2.1 Windows Server Hosting bundle successfully installed."
                 }
 
                 { $_ -in 3010, 3011 }
                 {
-                    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message ".NET Core Windows Server Hosting bundle successfully installed but a reboot is needed. Exit code: $exitCode"
+                    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message ".NET Core 2.1 Windows Server Hosting bundle successfully installed but a reboot is needed. Exit code: $exitCode"
                     $installResult.RebootNeeded = $true
                 }
 
                 default
                 {
-                    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 3 -Message "Error installing .NET Core Windows Server Hosting bundle. Exit code: $exitCode"
-                    WriteNonTerminalError -Message "Error installing .NET Core Windows Server Hosting bundle. Exit code: $exitCode"
+                    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 3 -Message "Error installing .NET Core 2.1 Windows Server Hosting bundle. Exit code: $exitCode"
+                    WriteNonTerminalError -Message "Error installing .NET Core 2.1 Windows Server Hosting bundle. Exit code: $exitCode"
 
                     $installResult.Success = $false
                     $installResult.ExitCode = $exitCode
-                    $installResult.Message = 'Error installing .NET Core Windows Server Hosting bundle'
+                    $installResult.Message = 'Error installing .NET Core 2.1 Windows Server Hosting bundle'
+
+                    return $installResult
+                }
+            }
+
+            # Install version 3.1
+            try
+            {
+                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Installing .NET Core 3.1 Windows Server Hosting bundle"
+                $exitCode = InstallDotNetCore -Sources $SourcePath
+            }
+            catch [System.IO.FileNotFoundException]
+            {
+                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Exception $_.Exception -Stream 3 -Message ".NET Core 3.1 installer not found"
+                WriteNonTerminalError -Message ".NET Core 3.1 installer not found"
+
+                $installResult.Success = $false
+                $installResult.ExitCode = -1
+                $installResult.Message = '.NET Core 3.1 installer not found'
+
+                return $installResult
+            }
+            catch
+            {
+                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Exception $_.Exception -Stream 3 -Message "Error downloading or starting the .NET Core 3.1 installation"
+                WriteNonTerminalError -Message "Error downloading or starting the .NET Core 3.1 installation"
+
+                $installResult.Success = $false
+                $installResult.ExitCode = -1
+                $installResult.Message = 'Error downloading or starting the .NET Core 3.1 installation'
+
+                return $installResult
+            }
+
+            switch ($exitCode)
+            {
+                0
+                {
+                    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message ".NET Core 3.1 Windows Server Hosting bundle successfully installed."
+                }
+
+                { $_ -in 3010, 3011 }
+                {
+                    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message ".NET Core 3.1 Windows Server Hosting bundle successfully installed but a reboot is needed. Exit code: $exitCode"
+                    $installResult.RebootNeeded = $true
+                }
+
+                default
+                {
+                    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 3 -Message "Error installing .NET Core 3.1 Windows Server Hosting bundle. Exit code: $exitCode"
+                    WriteNonTerminalError -Message "Error installing .NET Core 3.1 Windows Server Hosting bundle. Exit code: $exitCode"
+
+                    $installResult.Success = $false
+                    $installResult.ExitCode = $exitCode
+                    $installResult.Message = 'Error installing .NET Core 3.1 Windows Server Hosting bundle'
 
                     return $installResult
                 }

--- a/src/Outsystems.SetupTools/Lib/Constants.ps1
+++ b/src/Outsystems.SetupTools/Lib/Constants.ps1
@@ -92,6 +92,7 @@ $OSRepoURL = "https://ossetuptools.blob.core.windows.net/sources"
 $OSRepoURLBuildTools = 'https://download.microsoft.com/download/E/E/D/EEDF18A8-4AED-4CE0-BEBE-70A83094FC5A/BuildTools_Full.exe'
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
 $OSRepoURLDotNETCore = 'https://download.visualstudio.microsoft.com/download/pr/bdc70151-74f7-427c-a368-716d5f1840c5/6186889f6c784bae224eb15fb94c45fe/dotnet-hosting-3.1.14-win.exe'
+$OSRepoURLDotNETCore21 = 'https://download.visualstudio.microsoft.com/download/pr/eebd54bc-c3a2-4580-bb29-b35c1c5ffa92/22ffe5649861167d3d5728d3cb4b10a1/dotnet-hosting-2.1.12-win.exe'
 
 # .NET related
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]

--- a/src/Outsystems.SetupTools/Lib/Constants.ps1
+++ b/src/Outsystems.SetupTools/Lib/Constants.ps1
@@ -38,8 +38,6 @@ $OS10ReqsMinOSVersion = "6.2.0.0"
 $OS11ReqsMinOSVersion = "10.0.14393"
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
 $OSReqsMinOSProductType = 2
-[System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
-$OS11ReqsMinDotNetCoreVersion = "3.1.14"
 
 # Microsoft Build Tools 2015 MSI Product Codes
 
@@ -90,9 +88,6 @@ $OSSCCred = New-Object System.Management.Automation.PSCredential ($OSSCUser, $(C
 $OSRepoURL = "https://ossetuptools.blob.core.windows.net/sources"
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
 $OSRepoURLBuildTools = 'https://download.microsoft.com/download/E/E/D/EEDF18A8-4AED-4CE0-BEBE-70A83094FC5A/BuildTools_Full.exe'
-[System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
-$OSRepoURLDotNETCore = 'https://download.visualstudio.microsoft.com/download/pr/bdc70151-74f7-427c-a368-716d5f1840c5/6186889f6c784bae224eb15fb94c45fe/dotnet-hosting-3.1.14-win.exe'
-$OSRepoURLDotNETCore21 = 'https://download.visualstudio.microsoft.com/download/pr/eebd54bc-c3a2-4580-bb29-b35c1c5ffa92/22ffe5649861167d3d5728d3cb4b10a1/dotnet-hosting-2.1.12-win.exe'
 
 # .NET related
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
@@ -114,6 +109,21 @@ $OSDotNetReqForMajor = @{
         Value                = '461808'
         ToInstallVersion     = '4.7.2'
         ToInstallDownloadURL = 'https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe'
+    }
+}
+
+# .NET Core Hosting Bundle related
+[System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
+$OSDotNetCoreHostingBundleReq = @{
+    '2' = @{
+        Version = '2.1.12'
+        ToInstallDownloadURL = 'https://download.visualstudio.microsoft.com/download/pr/eebd54bc-c3a2-4580-bb29-b35c1c5ffa92/22ffe5649861167d3d5728d3cb4b10a1/dotnet-hosting-2.1.12-win.exe'
+        InstallerName = 'DotNetCore_WindowsHosting_21.exe'
+    }
+    '3' = @{
+        Version = '3.1.14'
+        ToInstallDownloadURL = 'https://download.visualstudio.microsoft.com/download/pr/bdc70151-74f7-427c-a368-716d5f1840c5/6186889f6c784bae224eb15fb94c45fe/dotnet-hosting-3.1.14-win.exe'
+        InstallerName = 'DotNetCore_WindowsHosting.exe'
     }
 }
 

--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -444,12 +444,12 @@ function InnerInstallDotNetCore([bool]$InstallVersion21, [string]$Sources)
 
 function InstallDotNetCore([string]$Sources)
 {
-    return InnerInstallDotNetCore -InstallVersion21 $False -Sources $SourcePath
+    return InnerInstallDotNetCore -InstallVersion21 $False -Sources $Sources
 }
 
 function InstallDotNetCore21([string]$Sources)
 {
-    return InnerInstallDotNetCore -InstallVersion21 $True -Sources $SourcePath
+    return InnerInstallDotNetCore -InstallVersion21 $True -Sources $Sources
 }
 
 function InstallErlang([string]$InstallDir, [string]$Sources)

--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -397,30 +397,41 @@ function InstallBuildTools([string]$Sources)
     return $($result.ExitCode)
 }
 
-function InstallDotNetCore([string]$Sources)
+function InnerInstallDotNetCore([bool]$InstallVersion21, [string]$Sources)
 {
+    if ($InstallVersion21)
+    {
+        $installerName = "DotNetCore_WindowsHosting21"
+        $installerRepoURL = $OSRepoURLDotNETCore21
+    }
+    else
+    {
+        $installerName = "DotNetCore_WindowsHosting"
+        $installerRepoURL = $OSRepoURLDotNETCore
+    }
+
     if ($Sources)
     {
-        if (Test-Path "$Sources\DotNetCore_WindowsHosting.exe")
+        if (Test-Path "$Sources\$installerName.exe")
         {
-            $installer = "$Sources\DotNetCore_WindowsHosting.exe"
+            $installer = "$Sources\$installerName.exe"
             LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Using local file: $installer"
         }
         # If Windows is set to hide file extensions from file names, the file could have been stored with double extension by mistake.
-        elseif (Test-Path "$Sources\DotNetCore_WindowsHosting.exe.exe")
+        elseif (Test-Path "$Sources\$installerName.exe.exe")
         {
-            $installer = "$Sources\DotNetCore_WindowsHosting.exe.exe"
+            $installer = "$Sources\$installerName.exe.exe"
             LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Using local fallback file: $installer"
         }
         else {
-            throw [System.IO.FileNotFoundException] "DotNetCore_WindowsHosting.exe not found."
+            throw [System.IO.FileNotFoundException] "$installerName.exe not found."
         }
     }
     else
     {
-        $installer = "$ENV:TEMP\DotNetCore_WindowsHosting.exe"
-        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Downloading sources from: $OSRepoURLDotNETCore"
-        DownloadOSSources -URL $OSRepoURLDotNETCore -SavePath $installer
+        $installer = "$ENV:TEMP\$installerName.exe"
+        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Downloading sources from: $installerRepoURL"
+        DownloadOSSources -URL $installerRepoURL -SavePath $installer
     }
 
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Starting the installation"
@@ -429,6 +440,16 @@ function InstallDotNetCore([string]$Sources)
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returnig $($result.ExitCode)"
 
     return $($result.ExitCode)
+}
+
+function InstallDotNetCore([string]$Sources)
+{
+    return InnerInstallDotNetCore -InstallVersion21 $False -Sources $SourcePath
+}
+
+function InstallDotNetCore21([string]$Sources)
+{
+    return InnerInstallDotNetCore -InstallVersion21 $True -Sources $SourcePath
 }
 
 function InstallErlang([string]$InstallDir, [string]$Sources)

--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -401,15 +401,15 @@ function InstallDotNetCoreHostingBundle([string]$MajorVersion, [string]$Sources)
 {
     if ($Sources)
     {
-        if (Test-Path "$Sources\$script:OSDotNetCoreHostingBundleReq[$MajorVersion]['InstallerName']")
+        if (Test-Path "$Sources\$($script:OSDotNetCoreHostingBundleReq[$MajorVersion]['InstallerName'])")
         {
-            $installer = "$Sources\$script:OSDotNetCoreHostingBundleReq[$MajorVersion]['InstallerName']"
+            $installer = "$Sources\$($script:OSDotNetCoreHostingBundleReq[$MajorVersion]['InstallerName'])"
             LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Using local file: $installer"
         }
         # If Windows is set to hide file extensions from file names, the file could have been stored with double extension by mistake.
-        elseif (Test-Path "$Sources\$script:OSDotNetCoreHostingBundleReq[$MajorVersion]['InstallerName'].exe")
+        elseif (Test-Path "$Sources\$($script:OSDotNetCoreHostingBundleReq[$MajorVersion]['InstallerName']).exe")
         {
-            $installer = "$script:OSDotNetCoreHostingBundleReq[$MajorVersion]['InstallerName'].exe"
+            $installer = "$($script:OSDotNetCoreHostingBundleReq[$MajorVersion]['InstallerName']).exe"
             LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Using local fallback file: $installer"
         }
         else {
@@ -418,9 +418,9 @@ function InstallDotNetCoreHostingBundle([string]$MajorVersion, [string]$Sources)
     }
     else
     {
-        $installer = "$ENV:TEMP\$script:OSDotNetCoreHostingBundleReq[$MajorVersion]['InstallerName']"
-        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Downloading sources from: $script:OSDotNetCoreHostingBundleReq[$MajorVersion]['ToInstallDownloadURL']"
-        DownloadOSSources -URL $script:OSDotNetCoreHostingBundleReq[$MajorVersion]['ToInstallDownloadURL'] -SavePath $installer
+        $installer = "$ENV:TEMP\$($script:OSDotNetCoreHostingBundleReq[$MajorVersion]['InstallerName'])"
+        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Downloading sources from: $($script:OSDotNetCoreHostingBundleReq[$MajorVersion]['ToInstallDownloadURL'])"
+        DownloadOSSources -URL $($script:OSDotNetCoreHostingBundleReq[$MajorVersion]['ToInstallDownloadURL']) -SavePath $installer
     }
 
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Starting the installation"

--- a/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
+++ b/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
@@ -12,7 +12,7 @@
 RootModule = 'OutSystems.SetupTools.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.12.0.0'
+ModuleVersion = '3.13.0.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/test/unit/Install-OSServerPreReqs.Tests.ps1
+++ b/test/unit/Install-OSServerPreReqs.Tests.ps1
@@ -8,13 +8,12 @@ InModuleScope -ModuleName OutSystems.SetupTools {
         Mock IsAdmin { return $true }
         Mock GetMSBuildToolsInstallInfo { return @{ 'HasMSBuild2015' = $False; 'HasMSBuild2017' = $False; 'LatestVersionInstalled' = $Null; 'RebootNeeded' = $False } }
         Mock GetDotNet4Version { return $null }
-        Mock GetWindowsServerHostingVersion { return $null }
+        Mock GetDotNetCoreHostingBundleVersions { return '0.0.0.0' }
 
         Mock InstallDotNet { return 0 }
         Mock InstallBuildTools { return 0 }
         Mock InstallWindowsFeatures { return @{ 'Output' = 'All good'; 'ExitCode' = @{ 'value__' = 0 }; 'RestartNeeded' = @{ 'value__' = 1 }; 'Success' = $true } }
-        Mock InstallDotNetCore21 { return 0 }
-        Mock InstallDotNetCore { return 0 }
+        Mock InstallDotNetCoreHostingBundle { return 0 }
         Mock ConfigureServiceWMI {}
         Mock ConfigureServiceWindowsSearch {}
         Mock DisableFIPS {}
@@ -27,10 +26,10 @@ InModuleScope -ModuleName OutSystems.SetupTools {
         $assNotRunInstallBuildTools = @{ 'CommandName' = 'InstallBuildTools'; 'Times' = 0; 'Exactly' = $true; 'Scope' = 'Context'}
         $assRunInstallWindowsFeatures = @{ 'CommandName' = 'InstallWindowsFeatures'; 'Times' = 1; 'Exactly' = $true; 'Scope' = 'Context'}
         $assNotRunInstallWindowsFeatures = @{ 'CommandName' = 'InstallWindowsFeatures'; 'Times' = 0; 'Exactly' = $true; 'Scope' = 'Context'}
-        $assRunInstallDotNetCore = @{ 'CommandName' = 'InstallDotNetCore'; 'Times' = 1; 'Exactly' = $true; 'Scope' = 'Context'}
-        $assNotRunInstallDotNetCore = @{ 'CommandName' = 'InstallDotNetCore'; 'Times' = 0; 'Exactly' = $true; 'Scope' = 'Context'}
-        $assRunInstallDotNetCore21 = @{ 'CommandName' = 'InstallDotNetCore21'; 'Times' = 1; 'Exactly' = $true; 'Scope' = 'Context'}
-        $assNotRunInstallDotNetCore21 = @{ 'CommandName' = 'InstallDotNetCore21'; 'Times' = 0; 'Exactly' = $true; 'Scope' = 'Context'}
+        $assRunInstallDotNetCore = @{ 'CommandName' = 'InstallDotNetCoreHostingBundle'; 'Times' = 1; 'Exactly' = $true; 'Scope' = 'Context'; 'ParameterFilter' = { $MajorVersion -eq "3" }}
+        $assNotRunInstallDotNetCore = @{ 'CommandName' = 'InstallDotNetCoreHostingBundle'; 'Times' = 0; 'Exactly' = $true; 'Scope' = 'Context'; 'ParameterFilter' = { $MajorVersion -eq "3" }}
+        $assRunInstallDotNetCore21 = @{ 'CommandName' = 'InstallDotNetCoreHostingBundle'; 'Times' = 1; 'Exactly' = $true; 'Scope' = 'Context'; 'ParameterFilter' = { $MajorVersion -eq "2" }}
+        $assNotRunInstallDotNetCore21 = @{ 'CommandName' = 'InstallDotNetCoreHostingBundle'; 'Times' = 0; 'Exactly' = $true; 'Scope' = 'Context'; 'ParameterFilter' = { $MajorVersion -eq "2" }}
         $assRunConfigureServiceWMI = @{ 'CommandName' = 'ConfigureServiceWMI'; 'Times' = 1; 'Exactly' = $true; 'Scope' = 'Context'}
         $assNotRunConfigureServiceWMI = @{ 'CommandName' = 'ConfigureServiceWMI'; 'Times' = 0; 'Exactly' = $true; 'Scope' = 'Context'}
         $assRunConfigureServiceWindowsSearch = @{ 'CommandName' = 'ConfigureServiceWindowsSearch'; 'Times' = 1; 'Exactly' = $true; 'Scope' = 'Context'}
@@ -121,7 +120,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
             Mock GetMSBuildToolsInstallInfo { return @{ 'HasMSBuild2015' = $True; 'HasMSBuild2017' = $False; 'LatestVersionInstalled' = 'MS Build Tools 2015'; 'RebootNeeded' = $False } }
             Mock GetDotNet4Version { return 461808 }
-            Mock GetWindowsServerHostingVersion { return '3.1.14' }
+            Mock GetDotNetCoreHostingBundleVersions { return @('3.1.14', '2.1.12') }
 
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
@@ -173,7 +172,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
             Mock GetMSBuildToolsInstallInfo { return @{ 'HasMSBuild2015' = $True; 'HasMSBuild2017' = $False; 'LatestVersionInstalled' = 'MS Build Tools 2015'; 'RebootNeeded' = $False } }
             Mock GetDotNet4Version { return 461808 }
-            Mock GetWindowsServerHostingVersion { return '3.1.14' }
+            Mock GetDotNetCoreHostingBundleVersions { return @('3.1.14', '2.1.12') }
 
             $result = Install-OSServerPreReqs -MajorVersion '12' -ErrorVariable err -ErrorAction SilentlyContinue
 
@@ -579,7 +578,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
         Context 'When .NET core installation fails to start' {
 
-            Mock InstallDotNetCore { throw 'Big error' }
+            Mock -CommandName InstallDotNetCoreHostingBundle -ParameterFilter { $MajorVersion -eq "3" } -MockWith { throw 'Big error' }
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should not run the next actions' {
@@ -606,7 +605,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
         Context 'When .NET core 2.1 installation fails to start' {
 
-            Mock InstallDotNetCore21 { throw 'Big error' }
+            Mock -CommandName InstallDotNetCoreHostingBundle -ParameterFilter { $MajorVersion -eq "2" } -MockWith { throw 'Big error' }
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should not run the next actions' {
@@ -633,7 +632,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
         Context 'When .NET core installer not found' {
 
-            Mock InstallDotNetCore { throw [System.IO.FileNotFoundException] '.NET Core 3.1 installer not found' }
+            Mock -CommandName InstallDotNetCoreHostingBundle -ParameterFilter { $MajorVersion -eq "3" } -MockWith { throw [System.IO.FileNotFoundException] '.NET Core 3.1 installer not found' }
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should not run the next actions' {
@@ -660,7 +659,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
         Context 'When .NET core 2.1 installer not found' {
 
-            Mock InstallDotNetCore21 { throw [System.IO.FileNotFoundException] '.NET Core 2.1 installer not found' }
+            Mock -CommandName InstallDotNetCoreHostingBundle -ParameterFilter { $MajorVersion -eq "2" } -MockWith { throw [System.IO.FileNotFoundException] '.NET Core 2.1 installer not found' }
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should not run the next actions' {
@@ -687,7 +686,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
         Context 'When .NET core reports a reboot' {
 
-            Mock InstallDotNetCore { return 3010 }
+            Mock -CommandName InstallDotNetCoreHostingBundle -ParameterFilter { $MajorVersion -eq "3" } -MockWith { return 3010 }
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run every action' {
@@ -714,7 +713,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
         Context 'When .NET core 2.1 reports a reboot' {
 
-            Mock InstallDotNetCore21 { return 3010 }
+            Mock -CommandName InstallDotNetCoreHostingBundle -ParameterFilter { $MajorVersion -eq "2" } -MockWith { return 3010 }
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run every action' {
@@ -741,7 +740,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
         Context 'When .NET core reports an error' {
 
-            Mock InstallDotNetCore { return 10 }
+            Mock -CommandName InstallDotNetCoreHostingBundle -ParameterFilter { $MajorVersion -eq "3" } -MockWith { return 10 }
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should not run the next actions' {
@@ -768,7 +767,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
         Context 'When .NET core 2.1 reports an error' {
 
-            Mock InstallDotNetCore21 { return 10 }
+            Mock -CommandName InstallDotNetCoreHostingBundle -ParameterFilter { $MajorVersion -eq "2" } -MockWith { return 10 }
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should not run the next actions' {

--- a/test/unit/Install-OSServerPreReqs.Tests.ps1
+++ b/test/unit/Install-OSServerPreReqs.Tests.ps1
@@ -587,7 +587,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
-                Assert-MockCalled @assNotRunInstallDotNetCore
+                Assert-MockCalled @assRunInstallDotNetCore
                 Assert-MockCalled @assNotRunConfigureServiceWMI
                 Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
                 Assert-MockCalled @assNotRunDisableFIPS
@@ -641,7 +641,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
-                Assert-MockCalled @assNotRunInstallDotNetCore
+                Assert-MockCalled @assRunInstallDotNetCore
                 Assert-MockCalled @assNotRunConfigureServiceWMI
                 Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
                 Assert-MockCalled @assNotRunDisableFIPS

--- a/test/unit/Install-OSServerPreReqs.Tests.ps1
+++ b/test/unit/Install-OSServerPreReqs.Tests.ps1
@@ -13,6 +13,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
         Mock InstallDotNet { return 0 }
         Mock InstallBuildTools { return 0 }
         Mock InstallWindowsFeatures { return @{ 'Output' = 'All good'; 'ExitCode' = @{ 'value__' = 0 }; 'RestartNeeded' = @{ 'value__' = 1 }; 'Success' = $true } }
+        Mock InstallDotNetCore21 { return 0 }
         Mock InstallDotNetCore { return 0 }
         Mock ConfigureServiceWMI {}
         Mock ConfigureServiceWindowsSearch {}
@@ -28,6 +29,8 @@ InModuleScope -ModuleName OutSystems.SetupTools {
         $assNotRunInstallWindowsFeatures = @{ 'CommandName' = 'InstallWindowsFeatures'; 'Times' = 0; 'Exactly' = $true; 'Scope' = 'Context'}
         $assRunInstallDotNetCore = @{ 'CommandName' = 'InstallDotNetCore'; 'Times' = 1; 'Exactly' = $true; 'Scope' = 'Context'}
         $assNotRunInstallDotNetCore = @{ 'CommandName' = 'InstallDotNetCore'; 'Times' = 0; 'Exactly' = $true; 'Scope' = 'Context'}
+        $assRunInstallDotNetCore21 = @{ 'CommandName' = 'InstallDotNetCore21'; 'Times' = 1; 'Exactly' = $true; 'Scope' = 'Context'}
+        $assNotRunInstallDotNetCore21 = @{ 'CommandName' = 'InstallDotNetCore21'; 'Times' = 0; 'Exactly' = $true; 'Scope' = 'Context'}
         $assRunConfigureServiceWMI = @{ 'CommandName' = 'ConfigureServiceWMI'; 'Times' = 1; 'Exactly' = $true; 'Scope' = 'Context'}
         $assNotRunConfigureServiceWMI = @{ 'CommandName' = 'ConfigureServiceWMI'; 'Times' = 0; 'Exactly' = $true; 'Scope' = 'Context'}
         $assRunConfigureServiceWindowsSearch = @{ 'CommandName' = 'ConfigureServiceWindowsSearch'; 'Times' = 1; 'Exactly' = $true; 'Scope' = 'Context'}
@@ -46,6 +49,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
             It 'Should run the BuildToold installation' { Assert-MockCalled @assRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
+            It 'Should not run the .NET 2.1 core installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
             It 'Should not run the .NET core installation' { Assert-MockCalled @assNotRunInstallDotNetCore }
             It 'Should configure the WMI service' { Assert-MockCalled @assRunConfigureServiceWMI }
             It 'Should configure the Windows search service' { Assert-MockCalled @assRunConfigureServiceWindowsSearch }
@@ -72,6 +76,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not run the .NET installation' { Assert-MockCalled @assNotRunInstallDotNet }
             It 'Should not run the BuildToold installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
+            It 'Should not run the .NET core 2.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
             It 'Should not run the .NET core installation' { Assert-MockCalled @assNotRunInstallDotNetCore }
             It 'Should configure the WMI service' { Assert-MockCalled @assRunConfigureServiceWMI }
             It 'Should configure the Windows search service' { Assert-MockCalled @assRunConfigureServiceWindowsSearch }
@@ -95,6 +100,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
             It 'Should run the BuildToold installation' { Assert-MockCalled @assRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
+            It 'Should run the .NET core 2.1 installation' { Assert-MockCalled @assRunInstallDotNetCore21 }
             It 'Should run the .NET core installation' { Assert-MockCalled @assRunInstallDotNetCore }
             It 'Should configure the WMI service' { Assert-MockCalled @assRunConfigureServiceWMI }
             It 'Should configure the Windows search service' { Assert-MockCalled @assRunConfigureServiceWindowsSearch }
@@ -122,6 +128,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not run the .NET installation' { Assert-MockCalled @assNotRunInstallDotNet }
             It 'Should not run the BuildToold installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
+            It 'Should not run the .NET core 2.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
             It 'Should not run the .NET core installation' { Assert-MockCalled @assNotRunInstallDotNetCore }
             It 'Should configure the WMI service' { Assert-MockCalled @assRunConfigureServiceWMI }
             It 'Should configure the Windows search service' { Assert-MockCalled @assRunConfigureServiceWindowsSearch }
@@ -145,6 +152,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
             It 'Should run the BuildToold installation' { Assert-MockCalled @assRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
+            It 'Should run the .NET core 2.1 installation' { Assert-MockCalled @assRunInstallDotNetCore21 }
             It 'Should run the .NET core installation' { Assert-MockCalled @assRunInstallDotNetCore }
             It 'Should configure the WMI service' { Assert-MockCalled @assRunConfigureServiceWMI }
             It 'Should configure the Windows search service' { Assert-MockCalled @assRunConfigureServiceWindowsSearch }
@@ -172,6 +180,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not run the .NET installation' { Assert-MockCalled @assNotRunInstallDotNet }
             It 'Should not run the BuildToold installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
+            It 'Should not run the .NET core 2.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
             It 'Should not run the .NET core installation' { Assert-MockCalled @assNotRunInstallDotNetCore }
             It 'Should configure the WMI service' { Assert-MockCalled @assRunConfigureServiceWMI }
             It 'Should configure the Windows search service' { Assert-MockCalled @assRunConfigureServiceWindowsSearch }
@@ -197,6 +206,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunInstallWindowsFeatures
+                Assert-MockCalled @assNotRunInstallDotNetCore21
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assNotRunConfigureServiceWMI
                 Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
@@ -223,6 +233,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 Assert-MockCalled @assRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
+                Assert-MockCalled @assNotRunInstallDotNetCore21
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assNotRunConfigureServiceWMI
                 Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
@@ -249,6 +260,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 Assert-MockCalled @assRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
+                Assert-MockCalled @assNotRunInstallDotNetCore21
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assNotRunConfigureServiceWMI
                 Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
@@ -275,6 +287,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 Assert-MockCalled @assRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
+                Assert-MockCalled @assNotRunInstallDotNetCore21
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assRunConfigureServiceWMI
                 Assert-MockCalled @assRunConfigureServiceWindowsSearch
@@ -301,6 +314,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 Assert-MockCalled @assRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
+                Assert-MockCalled @assNotRunInstallDotNetCore21
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assNotRunConfigureServiceWMI
                 Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
@@ -383,6 +397,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
+                Assert-MockCalled @assNotRunInstallDotNetCore21
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assNotRunConfigureServiceWMI
                 Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
@@ -409,6 +424,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
+                Assert-MockCalled @assNotRunInstallDotNetCore21
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assNotRunConfigureServiceWMI
                 Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
@@ -435,6 +451,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 Assert-MockCalled @assRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
+                Assert-MockCalled @assNotRunInstallDotNetCore21
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assRunConfigureServiceWMI
                 Assert-MockCalled @assRunConfigureServiceWindowsSearch
@@ -461,6 +478,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
+                Assert-MockCalled @assNotRunInstallDotNetCore21
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assNotRunConfigureServiceWMI
                 Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
@@ -486,6 +504,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not run the next actions' {
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assNotRunInstallBuildTools
+                Assert-MockCalled @assNotRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assNotRunConfigureServiceWMI
@@ -513,6 +532,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 Assert-MockCalled @assRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
+                Assert-MockCalled @assNotRunInstallDotNetCore21
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assRunConfigureServiceWMI
                 Assert-MockCalled @assRunConfigureServiceWindowsSearch
@@ -539,6 +559,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
+                Assert-MockCalled @assNotRunInstallDotNetCore21
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assNotRunConfigureServiceWMI
                 Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
@@ -565,7 +586,8 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
-                Assert-MockCalled @assRunInstallDotNetCore
+                Assert-MockCalled @assRunInstallDotNetCore21
+                Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assNotRunConfigureServiceWMI
                 Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
                 Assert-MockCalled @assNotRunDisableFIPS
@@ -576,22 +598,23 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 $result.Success | Should Be $false
                 $result.RebootNeeded | Should Be $false
                 $result.ExitCode | Should Be -1
-                $result.Message | Should Be 'Error downloading or starting the .NET Core installation'
+                $result.Message | Should Be 'Error downloading or starting the .NET Core 3.1 installation'
             }
-            It 'Should output an error' { $err[-1] | Should Be 'Error downloading or starting the .NET Core installation' }
+            It 'Should output an error' { $err[-1] | Should Be 'Error downloading or starting the .NET Core 3.1 installation' }
             It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -ErrorAction SilentlyContinue } | Should Not throw }
         }
 
-        Context 'When .NET core installer not found' {
+        Context 'When .NET core 2.1 installation fails to start' {
 
-            Mock InstallDotNetCore { throw [System.IO.FileNotFoundException] '.NET Core installer not found' }
+            Mock InstallDotNetCore21 { throw 'Big error' }
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should not run the next actions' {
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
-                Assert-MockCalled @assRunInstallDotNetCore
+                Assert-MockCalled @assRunInstallDotNetCore21
+                Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assNotRunConfigureServiceWMI
                 Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
                 Assert-MockCalled @assNotRunDisableFIPS
@@ -602,9 +625,63 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 $result.Success | Should Be $false
                 $result.RebootNeeded | Should Be $false
                 $result.ExitCode | Should Be -1
-                $result.Message | Should Be '.NET Core installer not found'
+                $result.Message | Should Be 'Error downloading or starting the .NET Core 2.1 installation'
             }
-            It 'Should output an error' { $err[-1] | Should Be '.NET Core installer not found' }
+            It 'Should output an error' { $err[-1] | Should Be 'Error downloading or starting the .NET Core 2.1 installation' }
+            It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -ErrorAction SilentlyContinue } | Should Not throw }
+        }
+
+        Context 'When .NET core installer not found' {
+
+            Mock InstallDotNetCore { throw [System.IO.FileNotFoundException] '.NET Core 3.1 installer not found' }
+            $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should not run the next actions' {
+                Assert-MockCalled @assNotRunInstallDotNet
+                Assert-MockCalled @assRunInstallBuildTools
+                Assert-MockCalled @assRunInstallWindowsFeatures
+                Assert-MockCalled @assRunInstallDotNetCore21
+                Assert-MockCalled @assNotRunInstallDotNetCore
+                Assert-MockCalled @assNotRunConfigureServiceWMI
+                Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
+                Assert-MockCalled @assNotRunDisableFIPS
+                Assert-MockCalled @assNotRunConfigureWindowsEventLog
+                Assert-MockCalled @assNotRunConfigureMSMQDomainServer
+            }
+            It 'Should return the right result' {
+                $result.Success | Should Be $false
+                $result.RebootNeeded | Should Be $false
+                $result.ExitCode | Should Be -1
+                $result.Message | Should Be '.NET Core 3.1 installer not found'
+            }
+            It 'Should output an error' { $err[-1] | Should Be '.NET Core 3.1 installer not found' }
+            It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -ErrorAction SilentlyContinue } | Should Not throw }
+        }
+
+        Context 'When .NET core 2.1 installer not found' {
+
+            Mock InstallDotNetCore21 { throw [System.IO.FileNotFoundException] '.NET Core 2.1 installer not found' }
+            $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should not run the next actions' {
+                Assert-MockCalled @assNotRunInstallDotNet
+                Assert-MockCalled @assRunInstallBuildTools
+                Assert-MockCalled @assRunInstallWindowsFeatures
+                Assert-MockCalled @assRunInstallDotNetCore21
+                Assert-MockCalled @assNotRunInstallDotNetCore
+                Assert-MockCalled @assNotRunConfigureServiceWMI
+                Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
+                Assert-MockCalled @assNotRunDisableFIPS
+                Assert-MockCalled @assNotRunConfigureWindowsEventLog
+                Assert-MockCalled @assNotRunConfigureMSMQDomainServer
+            }
+            It 'Should return the right result' {
+                $result.Success | Should Be $false
+                $result.RebootNeeded | Should Be $false
+                $result.ExitCode | Should Be -1
+                $result.Message | Should Be '.NET Core 2.1 installer not found'
+            }
+            It 'Should output an error' { $err[-1] | Should Be '.NET Core 2.1 installer not found' }
             It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -ErrorAction SilentlyContinue } | Should Not throw }
         }
 
@@ -617,6 +694,34 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 Assert-MockCalled @assRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
+                Assert-MockCalled @assRunInstallDotNetCore21
+                Assert-MockCalled @assRunInstallDotNetCore
+                Assert-MockCalled @assRunConfigureServiceWMI
+                Assert-MockCalled @assRunConfigureServiceWindowsSearch
+                Assert-MockCalled @assRunDisableFIPS
+                Assert-MockCalled @assRunConfigureWindowsEventLog
+                Assert-MockCalled @assNotRunConfigureMSMQDomainServer
+            }
+            It 'Should return the right result' {
+                $result.Success | Should Be $true
+                $result.RebootNeeded | Should Be $true
+                $result.ExitCode | Should Be 3010
+                $result.Message | Should Be 'Outsystems platform server pre-requisites successfully installed but a reboot is required'
+            }
+            It 'Should not output an error' { $err.Count | Should Be 0 }
+            It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -ErrorAction SilentlyContinue } | Should Not throw }
+        }
+
+        Context 'When .NET core 2.1 reports a reboot' {
+
+            Mock InstallDotNetCore21 { return 3010 }
+            $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should run every action' {
+                Assert-MockCalled @assRunInstallDotNet
+                Assert-MockCalled @assRunInstallBuildTools
+                Assert-MockCalled @assRunInstallWindowsFeatures
+                Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
                 Assert-MockCalled @assRunConfigureServiceWMI
                 Assert-MockCalled @assRunConfigureServiceWindowsSearch
@@ -642,8 +747,9 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not run the next actions' {
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
-                Assert-MockCalled @assRunInstallDotNetCore
                 Assert-MockCalled @assRunInstallWindowsFeatures
+                Assert-MockCalled @assRunInstallDotNetCore21
+                Assert-MockCalled @assRunInstallDotNetCore
                 Assert-MockCalled @assNotRunConfigureServiceWMI
                 Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
                 Assert-MockCalled @assNotRunDisableFIPS
@@ -654,9 +760,36 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 $result.Success | Should Be $false
                 $result.RebootNeeded | Should Be $false
                 $result.ExitCode | Should Be 10
-                $result.Message | Should Be 'Error installing .NET Core Windows Server Hosting bundle'
+                $result.Message | Should Be 'Error installing .NET Core 3.1 Windows Server Hosting bundle'
             }
-            It 'Should output an error' { $err[-1] | Should Be 'Error installing .NET Core Windows Server Hosting bundle. Exit code: 10' }
+            It 'Should output an error' { $err[-1] | Should Be 'Error installing .NET Core 3.1 Windows Server Hosting bundle. Exit code: 10' }
+            It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -ErrorAction SilentlyContinue } | Should Not throw }
+        }
+
+        Context 'When .NET core 2.1 reports an error' {
+
+            Mock InstallDotNetCore21 { return 10 }
+            $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should not run the next actions' {
+                Assert-MockCalled @assNotRunInstallDotNet
+                Assert-MockCalled @assRunInstallBuildTools
+                Assert-MockCalled @assRunInstallWindowsFeatures
+                Assert-MockCalled @assRunInstallDotNetCore21
+                Assert-MockCalled @assNotRunInstallDotNetCore
+                Assert-MockCalled @assNotRunConfigureServiceWMI
+                Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
+                Assert-MockCalled @assNotRunDisableFIPS
+                Assert-MockCalled @assNotRunConfigureWindowsEventLog
+                Assert-MockCalled @assNotRunConfigureMSMQDomainServer
+            }
+            It 'Should return the right result' {
+                $result.Success | Should Be $false
+                $result.RebootNeeded | Should Be $false
+                $result.ExitCode | Should Be 10
+                $result.Message | Should Be 'Error installing .NET Core 2.1 Windows Server Hosting bundle'
+            }
+            It 'Should output an error' { $err[-1] | Should Be 'Error installing .NET Core 2.1 Windows Server Hosting bundle. Exit code: 10' }
             It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -ErrorAction SilentlyContinue } | Should Not throw }
         }
 
@@ -668,6 +801,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not run the next actions' {
                 Assert-MockCalled @assRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
+                Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunConfigureServiceWMI
@@ -694,6 +828,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not run the next actions' {
                 Assert-MockCalled @assRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
+                Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunConfigureServiceWMI
@@ -720,6 +855,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not run the next actions' {
                 Assert-MockCalled @assRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
+                Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunConfigureServiceWMI
@@ -747,6 +883,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not run the next actions' {
                 Assert-MockCalled @assRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
+                Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunConfigureServiceWMI
@@ -773,6 +910,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not run the next actions' {
                 Assert-MockCalled @assRunInstallDotNet
                 Assert-MockCalled @assRunInstallBuildTools
+                Assert-MockCalled @assNotRunInstallDotNetCore21
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunConfigureServiceWMI

--- a/test/unit/Lib.Constants.Tests.ps1
+++ b/test/unit/Lib.Constants.Tests.ps1
@@ -48,6 +48,17 @@ Describe 'Lib Constants Tests' {
         }
     }
 
+    Context 'Check .NETCore 2.1 constants' {
+
+        $SavePath = "$env:TEMP\dotnetcore21.exe"
+        $FileHash = 'AC74CADB690D3A5A175CEDD0EF02A11ABE41A292F9C9055B28522E3EB7B02726'
+
+        It 'Should be downloadable and have the right file hash' {
+            (New-Object System.Net.WebClient).DownloadFile($OSRepoURLDotNETCore21, $SavePath)
+            $(Get-FileHash -Path $SavePath).Hash | Should Be $FileHash
+        }
+    }
+
     Context 'Check .NETCore constants' {
 
         $SavePath = "$env:TEMP\dotnetcore.exe"

--- a/test/unit/Lib.Constants.Tests.ps1
+++ b/test/unit/Lib.Constants.Tests.ps1
@@ -54,18 +54,18 @@ Describe 'Lib Constants Tests' {
         $FileHash = 'AC74CADB690D3A5A175CEDD0EF02A11ABE41A292F9C9055B28522E3EB7B02726'
 
         It 'Should be downloadable and have the right file hash' {
-            (New-Object System.Net.WebClient).DownloadFile($OSRepoURLDotNETCore21, $SavePath)
+            (New-Object System.Net.WebClient).DownloadFile($script:OSDotNetCoreHostingBundleReq['2']['ToInstallDownloadURL'], $SavePath)
             $(Get-FileHash -Path $SavePath).Hash | Should Be $FileHash
         }
     }
 
-    Context 'Check .NETCore constants' {
+    Context 'Check .NETCore 3.1 constants' {
 
         $SavePath = "$env:TEMP\dotnetcore.exe"
         $FileHash = '187179215D0C9DE82F6C6F005E08AC517E34E9689959964053B0F60FEDFD8302'
 
         It 'Should be downloadable and have the right file hash' {
-            (New-Object System.Net.WebClient).DownloadFile($OSRepoURLDotNETCore, $SavePath)
+            (New-Object System.Net.WebClient).DownloadFile($script:OSDotNetCoreHostingBundleReq['3']['ToInstallDownloadURL'], $SavePath)
             $(Get-FileHash -Path $SavePath).Hash | Should Be $FileHash
         }
     }


### PR DESCRIPTION
* Install both 2.1 and 3.1 .NET Core Windows Server Hosting bundles, to allow SetupTools to be used to install the pre-requisites of all OutSystems 11 versions
* Update 2.1 version downloaded in CreateOfflineBundle.ps1 script to be the same as used in Install-OSServerPreReqs.ps1
* Includes QA