### PR TITLE
Server PrivateKey being written on installer log files

### DIFF
--- a/src/Outsystems.SetupTools/Functions/Get-OSServerInfo.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSServerInfo.ps1
@@ -71,7 +71,8 @@ function Get-OSServerInfo
 
             if ($serverInfo.PrivateKey)
             {
-                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Server private key is: $($serverInfo.PrivateKey)"
+                $maskedPrivateKey = MaskKey -Text $serverInfo.PrivateKey
+                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Server private key is: $($maskedPrivateKey)"
             }
             else
             {

--- a/src/Outsystems.SetupTools/Functions/Get-OSServerPrivateKey.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSServerPrivateKey.ps1
@@ -74,7 +74,8 @@ function Get-OSServerPrivateKey
             return $null
         }
 
-        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Returning $privateKey"
+        $maskedPrivateKey = MaskKey -Text $privateKey
+        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Returning key $maskedPrivateKey"
         return $privateKey
     }
 

--- a/src/Outsystems.SetupTools/Functions/New-OSPlatformPrivateKey.ps1
+++ b/src/Outsystems.SetupTools/Functions/New-OSPlatformPrivateKey.ps1
@@ -39,7 +39,8 @@ function New-OSPlatformPrivateKey
             return $null
         }
 
-        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Returning: $newKey"
+        $maskedNewKey = Mask-Key -Text $newKey
+        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Returning new generated private key: $maskedNewKey"
         return $newKey
     }
 

--- a/src/Outsystems.SetupTools/Functions/Set-OSServerConfig.ps1
+++ b/src/Outsystems.SetupTools/Functions/Set-OSServerConfig.ps1
@@ -321,7 +321,18 @@ function Set-OSServerConfig
                 }
 
                 # Writting the value
-                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Setting '$SettingSection/$Setting' to '$Value'"
+                switch($Setting)
+                {
+                    {'RuntimePassword', 'SessionPassword', 'ServicePassword', 'AdminPassword', 'LogPassword'}
+                    {
+                        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Setting '$SettingSection/$Setting' to the provided value"
+                    }
+                    default
+                    {
+                        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Setting '$SettingSection/$Setting' to '$Value'"
+                    }
+                }
+
                 $hsConf.EnvironmentConfiguration.$SettingSection.SelectSingleNode($Setting).InnerXML = $Value
 
                 LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Saving configuration"

--- a/src/Outsystems.SetupTools/Lib/Common.ps1
+++ b/src/Outsystems.SetupTools/Lib/Common.ps1
@@ -335,3 +335,11 @@ function EncryptSetting([string]$Setting)
 
     return $encryptedSetting
 }
+
+function MaskKey([String]$Text)
+{
+    $startchar = [math]::min($Text.length - 4, $Text.length)
+    $startchar = [math]::max(0, $startchar)
+    $right = "**********$($Text.SubString($startchar ,[math]::min($Text.length, 4)))"
+    return $right
+}

--- a/test/unit/Common.Tests.ps1
+++ b/test/unit/Common.Tests.ps1
@@ -11,3 +11,14 @@ Describe 'GetHashedPassword Tests' {
         }
     }
 }
+
+Describe 'MaskKey Tests' {
+    Context 'Normal' {
+        It 'Checks if returns a partial masked string' {
+            MaskKey -Text "ThisIsTheSensitiveData" | Should BeLike "**********Data"
+        }
+        It 'Checks it does not fail on default values' {
+            MaskKey | Should BeLike "**********"
+        }
+    }
+}


### PR DESCRIPTION
- Added a text masking function to hide private keys from the log files.
- Prevented passwords used during the setup from being written to the log files.

issue: https://outsystemsrd.atlassian.net/browse/RPM-1093