### PR TITLE
R11PIT-242 - Unify SetupTools versions and behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Outsystems.SetupTools Release History
 
+## 3.14.0.0
+
+- Updated Install-OSServerPreReqs. Install .NET Core hosting bundle version 3.1.14 only if we are above OutSystems version 11.12.2.0. Added parameters so the full OutSystems version can be specified
+
 ## 3.13.1.0
 
 - Fixed Get-OSRepoAvailableVersions. Was getting versions from an old storage account

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.13.1.{build}
+version: 3.14.0.{build}
 
 only_commits:
   files:

--- a/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
@@ -12,6 +12,14 @@ function Install-OSServerPreReqs
     Specifies the platform major version.
     Accepted values: 10 or 11.
 
+    .PARAMETER MinorVersion
+    Specifies the platform minor version.
+    Accepted values: one or more digit numbers.
+
+    .PARAMETER PatchVersion
+    Specifies the platform patch version.
+    Accepted values: single digits only.
+
     .PARAMETER InstallIISMgmtConsole
     Specifies if the IIS Managament Console will be installed.
     On servers without GUI this feature can't be installed so you should set this parameter to $false.
@@ -21,6 +29,9 @@ function Install-OSServerPreReqs
 
     .EXAMPLE
     Install-OSServerPreReqs -MajorVersion "10"
+
+    .EXAMPLE
+    Install-OSServerPreReqs -MajorVersion "11" -MinorVersion "12" -PatchVersion "3"
 
     .EXAMPLE
     Install-OSServerPreReqs -MajorVersion "11" -InstallIISMgmtConsole:$false

--- a/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
@@ -56,7 +56,6 @@ function Install-OSServerPreReqs
 
     begin
     {
-        Write-Host "Minor $MinorVersion"
         LogMessage -Function $($MyInvocation.Mycommand) -Phase 0 -Stream 0 -Message "Starting"
         SendFunctionStartEvent -InvocationInfo $MyInvocation
 

--- a/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
@@ -148,8 +148,17 @@ function Install-OSServerPreReqs
             {
                 # Check .NET Core Windows Server Hosting version
                 # Check optional minor and patch versions to check if we should install .NET Core 2 for compatibility
-                $installDotNetCoreHostingBundle2 = ShouldInstallDotNetCoreHostingBundleVersion2 -MinorVersion $MinorVersion -PatchVersion $PatchVersion
-                $installDotNetCoreHostingBundle3 = $true
+                $installDotNetCoreHostingBundle2 = ShouldInstallDotNetCoreHostingBundleVersion2 -MajorVersion $MajorVersion -MinorVersion $MinorVersion -PatchVersion $PatchVersion
+
+                #If we decided to install .NET Core 2.1 by checking the optional parameters, it means we don't need to install .NET Core 3.1
+                if ($installDotNetCoreHostingBundle2 -eq $true -and ($MinorVersion -ne '' -and $PatchVersion -ne '')) {
+                    $installDotNetCoreHostingBundle3 = $false
+                }
+                else
+                {
+                    $installDotNetCoreHostingBundle3 = $true
+                }
+
                 foreach ($version in GetDotNetCoreHostingBundleVersions)
                 {
                     # Check version 2.1

--- a/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
@@ -43,11 +43,20 @@ function Install-OSServerPreReqs
         [string]$SourcePath,
 
         [Parameter()]
-        [bool]$InstallIISMgmtConsole = $true
+        [bool]$InstallIISMgmtConsole = $true,
+
+        [Parameter()]
+        [ValidatePattern('\d+')]
+        [string]$MinorVersion,
+
+        [Parameter()]
+        [ValidatePattern('\d$')]
+        [string]$PatchVersion
     )
 
     begin
     {
+        Write-Host "Minor $MinorVersion"
         LogMessage -Function $($MyInvocation.Mycommand) -Phase 0 -Stream 0 -Message "Starting"
         SendFunctionStartEvent -InvocationInfo $MyInvocation
 
@@ -128,7 +137,8 @@ function Install-OSServerPreReqs
             default
             {
                 # Check .NET Core Windows Server Hosting version
-                $installDotNetCoreHostingBundle2 = $true
+                # Check optional minor and patch versions to check if we should install .NET Core 2 for compatibility
+                $installDotNetCoreHostingBundle2 = ShouldInstallDotNetCoreHostingBundleVersion2 -MinorVersion $MinorVersion -PatchVersion $PatchVersion
                 $installDotNetCoreHostingBundle3 = $true
                 foreach ($version in GetDotNetCoreHostingBundleVersions)
                 {

--- a/src/Outsystems.SetupTools/Lib/Constants.ps1
+++ b/src/Outsystems.SetupTools/Lib/Constants.ps1
@@ -118,12 +118,12 @@ $OSDotNetCoreHostingBundleReq = @{
     '2' = @{
         Version = '2.1.12'
         ToInstallDownloadURL = 'https://download.visualstudio.microsoft.com/download/pr/eebd54bc-c3a2-4580-bb29-b35c1c5ffa92/22ffe5649861167d3d5728d3cb4b10a1/dotnet-hosting-2.1.12-win.exe'
-        InstallerName = 'DotNetCore_WindowsHosting_21.exe'
+        InstallerName = 'DotNetCore_WindowsHosting.exe'
     }
     '3' = @{
         Version = '3.1.14'
         ToInstallDownloadURL = 'https://download.visualstudio.microsoft.com/download/pr/bdc70151-74f7-427c-a368-716d5f1840c5/6186889f6c784bae224eb15fb94c45fe/dotnet-hosting-3.1.14-win.exe'
-        InstallerName = 'DotNetCore_WindowsHosting.exe'
+        InstallerName = 'DotNetCore_WindowsHosting_31.exe'
     }
 }
 

--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -133,16 +133,17 @@ function GetDotNetCoreHostingBundleVersions()
     return $version
 }
 
-function ShouldInstallDotNetCoreHostingBundleVersion2([string]$MinorVersion, [string]$PatchVersion)
+function ShouldInstallDotNetCoreHostingBundleVersion2([string]$MajorVersion, [string]$MinorVersion, [string]$PatchVersion)
 {
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Checking which versions of .NET Core Hosting Bundle should be installed"
 
+    $MajorVersion = $MajorVersion -as [int]
     $MinorVersion = $MinorVersion -as [int]
     $PatchVersion = $PatchVersion -as [int]
     $shouldInstallDotNetCoreHostingBundleVersion2 = $true
 
 
-    if ($MinorVersion -gt 12 -or ($MinorVersion -eq 12 -and $PatchVersion -ge 2))
+    if ($MajorVersion -eq 11 -and $MinorVersion -gt 12 -or ($MinorVersion -eq 12 -and $PatchVersion -ge 2))
     {
         $shouldInstallDotNetCoreHostingBundleVersion2 = $false
     }

--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -133,6 +133,25 @@ function GetDotNetCoreHostingBundleVersions()
     return $version
 }
 
+function ShouldInstallDotNetCoreHostingBundleVersion2([string]$MinorVersion, [string]$PatchVersion)
+{
+    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Checking which versions of .NET Core Hosting Bundle should be installed"
+
+    $MinorVersion = $MinorVersion -as [int]
+    $PatchVersion = $PatchVersion -as [int]
+    $shouldInstallDotNetCoreHostingBundleVersion2 = $true
+
+
+    if ($MinorVersion -gt 12 -or ($MinorVersion -eq 12 -and $PatchVersion -ge 2))
+    {
+        $shouldInstallDotNetCoreHostingBundleVersion2 = $false
+    }
+
+    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Should install .NET Core Hosting Bundle Version 2: $shouldInstallDotNetCoreHostingBundleVersion2"
+
+    return $shouldInstallDotNetCoreHostingBundleVersion2
+}
+
 function InstallDotNet([string]$Sources, [string]$URL)
 {
     if ($Sources)

--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -133,26 +133,6 @@ function GetDotNetCoreHostingBundleVersions()
     return $version
 }
 
-function ShouldInstallDotNetCoreHostingBundleVersion2([string]$MajorVersion, [string]$MinorVersion, [string]$PatchVersion)
-{
-    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Checking which versions of .NET Core Hosting Bundle should be installed"
-
-    $MajorVersion = $MajorVersion -as [int]
-    $MinorVersion = $MinorVersion -as [int]
-    $PatchVersion = $PatchVersion -as [int]
-    $shouldInstallDotNetCoreHostingBundleVersion2 = $true
-
-
-    if ($MajorVersion -eq 11 -and $MinorVersion -gt 12 -or ($MinorVersion -eq 12 -and $PatchVersion -ge 2))
-    {
-        $shouldInstallDotNetCoreHostingBundleVersion2 = $false
-    }
-
-    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Should install .NET Core Hosting Bundle Version 2: $shouldInstallDotNetCoreHostingBundleVersion2"
-
-    return $shouldInstallDotNetCoreHostingBundleVersion2
-}
-
 function InstallDotNet([string]$Sources, [string]$URL)
 {
     if ($Sources)

--- a/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
+++ b/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
@@ -12,7 +12,7 @@
 RootModule = 'OutSystems.SetupTools.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.13.1.0'
+ModuleVersion = '3.14.0.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/test/unit/Install-OSServerPreReqs.Tests.ps1
+++ b/test/unit/Install-OSServerPreReqs.Tests.ps1
@@ -927,5 +927,101 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should output an error' { $err[-1] | Should Be 'Error configuring the Message Queuing service' }
             It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '10' -ErrorAction SilentlyContinue } | Should Not throw }
         }
+
+        Context 'When trying to install prerequisites for a OS 11 version in Minor version 12 and Patch version newer than 2 (11.12.3)' {
+
+            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '12' -PatchVersion '3' -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
+            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
+            It 'Should not run the .NET core 2.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
+            It 'Should run the .NET core installation' { Assert-MockCalled @assRunInstallDotNetCore }
+            It 'Should configure the WMI service' { Assert-MockCalled @assRunConfigureServiceWMI }
+            It 'Should configure the Windows search service' { Assert-MockCalled @assRunConfigureServiceWindowsSearch }
+            It 'Should disable the FIPS' { Assert-MockCalled @assRunDisableFIPS }
+            It 'Should configure the windows event log' { Assert-MockCalled @assRunConfigureWindowsEventLog }
+            It 'Should not configure the MSMQ' { Assert-MockCalled @assNotRunConfigureMSMQDomainServer }
+
+            It 'Should return the right result' {
+                $result.Success | Should Be $true
+                $result.RebootNeeded | Should Be $false
+                $result.ExitCode | Should Be 0
+                $result.Message | Should Be 'OutSystems platform server pre-requisites successfully installed'
+            }
+            It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '12' -PatchVersion '3' -ErrorVariable err -ErrorAction SilentlyContinue } | Should Not throw }
+        }
+
+        Context 'When trying to install prerequisites for a OS 11 version in Minor version 12 and Patch version older than 2 (11.12.1)' {
+
+            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '12' -PatchVersion '1' -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
+            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
+            It 'Should run the .NET core 2.1 installation' { Assert-MockCalled @assRunInstallDotNetCore21 }
+            It 'Should run the .NET core installation' { Assert-MockCalled @assRunInstallDotNetCore }
+            It 'Should configure the WMI service' { Assert-MockCalled @assRunConfigureServiceWMI }
+            It 'Should configure the Windows search service' { Assert-MockCalled @assRunConfigureServiceWindowsSearch }
+            It 'Should disable the FIPS' { Assert-MockCalled @assRunDisableFIPS }
+            It 'Should configure the windows event log' { Assert-MockCalled @assRunConfigureWindowsEventLog }
+            It 'Should not configure the MSMQ' { Assert-MockCalled @assNotRunConfigureMSMQDomainServer }
+
+            It 'Should return the right result' {
+                $result.Success | Should Be $true
+                $result.RebootNeeded | Should Be $false
+                $result.ExitCode | Should Be 0
+                $result.Message | Should Be 'OutSystems platform server pre-requisites successfully installed'
+            }
+            It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '12' -PatchVersion '1' -ErrorVariable err -ErrorAction SilentlyContinue } | Should Not throw }
+        }
+
+        Context 'When trying to install prerequisites for a OS 11 version in Minor version 13 (11.13.0)' {
+
+            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '13' -PatchVersion '0' -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
+            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
+            It 'Should not run the .NET core 2.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
+            It 'Should run the .NET core installation' { Assert-MockCalled @assRunInstallDotNetCore }
+            It 'Should configure the WMI service' { Assert-MockCalled @assRunConfigureServiceWMI }
+            It 'Should configure the Windows search service' { Assert-MockCalled @assRunConfigureServiceWindowsSearch }
+            It 'Should disable the FIPS' { Assert-MockCalled @assRunDisableFIPS }
+            It 'Should configure the windows event log' { Assert-MockCalled @assRunConfigureWindowsEventLog }
+            It 'Should not configure the MSMQ' { Assert-MockCalled @assNotRunConfigureMSMQDomainServer }
+
+            It 'Should return the right result' {
+                $result.Success | Should Be $true
+                $result.RebootNeeded | Should Be $false
+                $result.ExitCode | Should Be 0
+                $result.Message | Should Be 'OutSystems platform server pre-requisites successfully installed'
+            }
+            It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '13' -PatchVersion '0' -ErrorVariable err -ErrorAction SilentlyContinue } | Should Not throw }
+        }
+
+        Context 'When trying to install prerequisites for a OS 11 version without passing the optional Minor and Patch Versions' {
+
+            $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
+            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
+            It 'Should run the .NET core 2.1 installation' { Assert-MockCalled @assRunInstallDotNetCore21}
+            It 'Should run the .NET core installation' { Assert-MockCalled @assRunInstallDotNetCore }
+            It 'Should configure the WMI service' { Assert-MockCalled @assRunConfigureServiceWMI }
+            It 'Should configure the Windows search service' { Assert-MockCalled @assRunConfigureServiceWindowsSearch }
+            It 'Should disable the FIPS' { Assert-MockCalled @assRunDisableFIPS }
+            It 'Should configure the windows event log' { Assert-MockCalled @assRunConfigureWindowsEventLog }
+            It 'Should not configure the MSMQ' { Assert-MockCalled @assNotRunConfigureMSMQDomainServer }
+
+            It 'Should return the right result' {
+                $result.Success | Should Be $true
+                $result.RebootNeeded | Should Be $false
+                $result.ExitCode | Should Be 0
+                $result.Message | Should Be 'OutSystems platform server pre-requisites successfully installed'
+            }
+            It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue } | Should Not throw }
+        }
     }
 }

--- a/test/unit/Install-OSServerPreReqs.Tests.ps1
+++ b/test/unit/Install-OSServerPreReqs.Tests.ps1
@@ -936,7 +936,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should not run the .NET core 2.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
-            It 'Should run the .NET core installation' { Assert-MockCalled @assRunInstallDotNetCore }
+            It 'Should run the .NET core 3.1 installation' { Assert-MockCalled @assRunInstallDotNetCore }
             It 'Should configure the WMI service' { Assert-MockCalled @assRunConfigureServiceWMI }
             It 'Should configure the Windows search service' { Assert-MockCalled @assRunConfigureServiceWindowsSearch }
             It 'Should disable the FIPS' { Assert-MockCalled @assRunDisableFIPS }
@@ -960,7 +960,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should run the .NET core 2.1 installation' { Assert-MockCalled @assRunInstallDotNetCore21 }
-            It 'Should run the .NET core installation' { Assert-MockCalled @assRunInstallDotNetCore }
+            It 'Should not run the .NET core 3.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore }
             It 'Should configure the WMI service' { Assert-MockCalled @assRunConfigureServiceWMI }
             It 'Should configure the Windows search service' { Assert-MockCalled @assRunConfigureServiceWindowsSearch }
             It 'Should disable the FIPS' { Assert-MockCalled @assRunDisableFIPS }


### PR DESCRIPTION
The goal of this PR is to unify the behavior of SetupTools when it comes to dealing with .NET Core Hosting versions 2.1 and 3.1.
Previously we had 2 versions, 3.12 which was being included in the installer, and only installed .NET Core 3.1, and 3.13.* which was the latest version available, which tried to install both .NET Core 2.1 and 3.1 versions.

With the proposed changes, we will only need to support a single version of SetupTools (which will ease the inclusion of new features and fixes in this module). The new behavior will be the following:

* If we specify MinorVersion and PatchVersion parameters when calling Install-OSServerPreReqs script, the script will check if we should install .NET Core 2.1 ( will only happen if PS version < 11.12.2 ).
* If we don't specify any of these parameters, we will proceed with the previous behavior of trying to install both versions.

In this PR we also changed the name of the prerequisites binaries to fix a bug that could break the offline installation scenario.