### PR TITLE
R11PIT-242 - Update installer to install only one .Net Core version

### DIFF
--- a/examples/DeployOnPrem/CreateOfflineBundle.ps1
+++ b/examples/DeployOnPrem/CreateOfflineBundle.ps1
@@ -10,8 +10,8 @@ Write-Verbose "Starting. Please wait..." -Verbose
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $OSRepoURLDotNET = 'https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe'
 $OSRepoURLBuildTools = 'https://download.microsoft.com/download/E/E/D/EEDF18A8-4AED-4CE0-BEBE-70A83094FC5A/BuildTools_Full.exe'
-$OSRepoURLDotNETCore = 'https://download.visualstudio.microsoft.com/download/pr/bdc70151-74f7-427c-a368-716d5f1840c5/6186889f6c784bae224eb15fb94c45fe/dotnet-hosting-3.1.14-win.exe'
-$OSRepoURLDotNETCore21 = 'https://download.visualstudio.microsoft.com/download/pr/eebd54bc-c3a2-4580-bb29-b35c1c5ffa92/22ffe5649861167d3d5728d3cb4b10a1/dotnet-hosting-2.1.12-win.exe'
+$OSRepoURLDotNETCore31 = 'https://download.visualstudio.microsoft.com/download/pr/bdc70151-74f7-427c-a368-716d5f1840c5/6186889f6c784bae224eb15fb94c45fe/dotnet-hosting-3.1.14-win.exe'
+$OSRepoURLDotNETCore = 'https://download.visualstudio.microsoft.com/download/pr/eebd54bc-c3a2-4580-bb29-b35c1c5ffa92/22ffe5649861167d3d5728d3cb4b10a1/dotnet-hosting-2.1.12-win.exe'
 $OSRepoURL = 'https://myfilerepo.blob.core.windows.net/sources'
 $OSServerVersion = ""
 $OSServiceStudioVersion = ""
@@ -41,9 +41,9 @@ Write-Verbose "Downloading .NET 4.7.2" -Verbose
 Write-Verbose "Downloading BuildTools 2015" -Verbose
 (New-Object System.Net.WebClient).DownloadFile($OSRepoURLBuildTools, "$env:Temp\OSOfflineBundle\PreReqs\BuildTools_Full.exe")
 Write-Verbose "Downloading .NET Core 2.1 Windows Server Hosting bundle" -Verbose
-(New-Object System.Net.WebClient).DownloadFile($OSRepoURLDotNETCore21, "$env:Temp\OSOfflineBundle\PreReqs\DotNetCore_WindowsHosting21.exe")
-Write-Verbose "Downloading .NET Core 3.1 Windows Server Hosting bundle" -Verbose
 (New-Object System.Net.WebClient).DownloadFile($OSRepoURLDotNETCore, "$env:Temp\OSOfflineBundle\PreReqs\DotNetCore_WindowsHosting.exe")
+Write-Verbose "Downloading .NET Core 3.1 Windows Server Hosting bundle" -Verbose
+(New-Object System.Net.WebClient).DownloadFile($OSRepoURLDotNETCore31, "$env:Temp\OSOfflineBundle\PreReqs\DotNetCore_WindowsHosting_31.exe")
 
 # -- Download outsystems
 $OSServerVersion = Get-OSRepoAvailableVersions -Application 'PlatformServer' -MajorVersion $MajorVersion -Latest

--- a/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
@@ -11,8 +11,19 @@ function Get-OSServerPreReqs
     Specifies the platform major version.
     Accepted values: 10 or 11
 
+    .PARAMETER MinorVersion
+    Specifies the platform minor version.
+    Accepted values: one or more digit numbers.
+
+    .PARAMETER PatchVersion
+    Specifies the platform patch version.
+    Accepted values: single digits only.
+
     .EXAMPLE
     Get-OSServerPreReqs -MajorVersion "10"
+
+    .EXAMPLE
+    Get-OSServerPreReqs -MajorVersion "11" -MinorVersion "12" -PatchVersion "3"
     #>
 
     [CmdletBinding()]
@@ -20,7 +31,15 @@ function Get-OSServerPreReqs
     param(
         [Parameter(Mandatory = $true)]
         [ValidatePattern('1[0-1]{1}(\.0)?')]
-        [string]$MajorVersion
+        [string]$MajorVersion,
+
+        [Parameter()]
+        [ValidatePattern('\d+')]
+        [string]$MinorVersion = "0",
+
+        [Parameter()]
+        [ValidatePattern('\d$')]
+        [string]$PatchVersion = "0"
     )
 
     begin
@@ -144,36 +163,95 @@ function Get-OSServerPreReqs
             }
             default
             {
-                $RequirementStatuses += CreateRequirementStatus -Title ".NET Core Windows Server Hosting" `
-                                                                -ScriptBlock `
-                                                                {
-                                                                    $Status = $([version](GetDotNetCoreHostingBundleVersions | Select-Object -First 1) -ge [version]$script:OSDotNetCoreHostingBundleReq['3']['Version'])
-                                                                    $OKMessages = @("Minimum .NET Core Windows Server Hosting found.")
-                                                                    $NOKMessages = @("Minimum .NET Core Windows Server Hosting not found.")
-                                                                    $IISStatus = $True
+                # Check .NET Core Windows Server Hosting version
+                $fullVersion = [version]"$MajorVersion.$MinorVersion.$PatchVersion.0"
+                if ($fullVersion -eq [version]"$MajorVersion.0.0.0")
+                {
+                    # Here means that no specific minor and patch version were specified
+                    # So we install both versions
+                    $requireDotNetCoreHostingBundle2 = $true
+                    $requireDotNetCoreHostingBundle3 = $true
+                }
+                elseif ($fullVersion -ge [version]"11.12.2.0")
+                {
+                    # Here means that minor and patch version were specified and we are equal or above version 11.12.2.0
+                    # We install version 3 only
+                    $requireDotNetCoreHostingBundle2 = $false
+                    $requireDotNetCoreHostingBundle3 = $true
+                }
+                else
+                {
+                    # Here means that minor and patch version were specified and we are below version 11.12.2.0
+                    # We install version 2 only
+                    $requireDotNetCoreHostingBundle2 = $true
+                    $requireDotNetCoreHostingBundle3 = $false
+                }
 
-                                                                    if (Get-Command Get-WebGlobalModule -errorAction SilentlyContinue)
+                if($requireDotNetCoreHostingBundle2) {
+                    $RequirementStatuses += CreateRequirementStatus -Title ".NET Core 2.1 Windows Server Hosting" `
+                                                                    -ScriptBlock `
                                                                     {
-                                                                        $aspModules = Get-WebGlobalModule | Where-Object { $_.Name -like "aspnetcoremodule*" }
-                                                                        if ($Status)
+                                                                        $Status = $([version](GetDotNetCoreHostingBundleVersions | Select-Object -First 1) -ge [version]$script:OSDotNetCoreHostingBundleReq['2']['Version'])
+                                                                        $OKMessages = @("Minimum .NET Core 2.1 Windows Server Hosting found.")
+                                                                        $NOKMessages = @("Minimum .NET Core 2.1 Windows Server Hosting not found.")
+                                                                        $IISStatus = $True
+
+                                                                        if (Get-Command Get-WebGlobalModule -errorAction SilentlyContinue)
                                                                         {
-                                                                            # Check if IIS can find ASP.NET modules
-                                                                            if ($aspModules.Count -lt 1)
+                                                                            $aspModules = Get-WebGlobalModule | Where-Object { $_.Name -like "aspnetcoremodule*" }
+                                                                            if ($Status)
                                                                             {
-                                                                                $Status = $False
-                                                                                $IISStatus = $False
-                                                                                $NOKMessages = @("IIS can't find ASP.NET modules")
-                                                                            }
-                                                                            else
-                                                                            {
-                                                                                $IISStatus = $True
+                                                                                # Check if IIS can find ASP.NET modules
+                                                                                if ($aspModules.Count -lt 1)
+                                                                                {
+                                                                                    $Status = $False
+                                                                                    $IISStatus = $False
+                                                                                    $NOKMessages = @("IIS can't find ASP.NET modules")
+                                                                                }
+                                                                                else
+                                                                                {
+                                                                                    $IISStatus = $True
+                                                                                }
                                                                             }
                                                                         }
+
+
+                                                                        return $(CreateResult -Status $Status -IISStatus $IISStatus -OKMessages $OKMessages -NOKMessages $NOKMessages)
                                                                     }
+                }
+
+                if($requireDotNetCoreHostingBundle3) {
+                    $RequirementStatuses += CreateRequirementStatus -Title ".NET Core 3.1 Windows Server Hosting" `
+                                                                    -ScriptBlock `
+                                                                    {
+                                                                        $Status = $([version](GetDotNetCoreHostingBundleVersions | Select-Object -First 1) -ge [version]$script:OSDotNetCoreHostingBundleReq['3']['Version'])
+                                                                        $OKMessages = @("Minimum .NET Core 3.1 Windows Server Hosting found.")
+                                                                        $NOKMessages = @("Minimum .NET Core 3.1 Windows Server Hosting not found.")
+                                                                        $IISStatus = $True
+
+                                                                        if (Get-Command Get-WebGlobalModule -errorAction SilentlyContinue)
+                                                                        {
+                                                                            $aspModules = Get-WebGlobalModule | Where-Object { $_.Name -eq "aspnetcoremodulev2" }
+                                                                            if ($Status)
+                                                                            {
+                                                                                # Check if IIS can find ASP.NET modules
+                                                                                if ($aspModules.Count -lt 1)
+                                                                                {
+                                                                                    $Status = $False
+                                                                                    $IISStatus = $False
+                                                                                    $NOKMessages = @("IIS can't find ASP.NET modules")
+                                                                                }
+                                                                                else
+                                                                                {
+                                                                                    $IISStatus = $True
+                                                                                }
+                                                                            }
+                                                                        }
 
 
-                                                                    return $(CreateResult -Status $Status -IISStatus $IISStatus -OKMessages $OKMessages -NOKMessages $NOKMessages)
-                                                                }
+                                                                        return $(CreateResult -Status $Status -IISStatus $IISStatus -OKMessages $OKMessages -NOKMessages $NOKMessages)
+                                                                    }
+                }
             }
         }
 

--- a/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
@@ -191,7 +191,14 @@ function Get-OSServerPreReqs
                     $RequirementStatuses += CreateRequirementStatus -Title ".NET Core 2.1 Windows Server Hosting" `
                                                                     -ScriptBlock `
                                                                     {
-                                                                        $Status = $([version](GetDotNetCoreHostingBundleVersions | Select-Object -First 1) -ge [version]$script:OSDotNetCoreHostingBundleReq['2']['Version'])
+                                                                        $Status = $False
+                                                                        foreach ($version in GetDotNetCoreHostingBundleVersions)
+                                                                        {
+                                                                            # Check version 2.1
+                                                                            if (([version]$version).Major -eq 2 -and ([version]$version) -ge [version]$script:OSDotNetCoreHostingBundleReq['2']['Version']) {
+                                                                                $Status = $True
+                                                                            }
+                                                                        }
                                                                         $OKMessages = @("Minimum .NET Core 2.1 Windows Server Hosting found.")
                                                                         $NOKMessages = @("Minimum .NET Core 2.1 Windows Server Hosting not found.")
                                                                         $IISStatus = $True
@@ -224,7 +231,14 @@ function Get-OSServerPreReqs
                     $RequirementStatuses += CreateRequirementStatus -Title ".NET Core 3.1 Windows Server Hosting" `
                                                                     -ScriptBlock `
                                                                     {
-                                                                        $Status = $([version](GetDotNetCoreHostingBundleVersions | Select-Object -First 1) -ge [version]$script:OSDotNetCoreHostingBundleReq['3']['Version'])
+                                                                        $Status = $False
+                                                                        foreach ($version in GetDotNetCoreHostingBundleVersions)
+                                                                        {
+                                                                            # Check version 3.1
+                                                                            if (([version]$version).Major -eq 3 -and ([version]$version) -ge [version]$script:OSDotNetCoreHostingBundleReq['3']['Version']) {
+                                                                                $Status = $True
+                                                                            }
+                                                                        }
                                                                         $OKMessages = @("Minimum .NET Core 3.1 Windows Server Hosting found.")
                                                                         $NOKMessages = @("Minimum .NET Core 3.1 Windows Server Hosting not found.")
                                                                         $IISStatus = $True


### PR DESCRIPTION
* Fix executable names in CreateOfflineBundle.ps1.
* Update Get-OSServerPreReqs to support receiving minor and patch version numbers.