### PR TITLE
R11PIT-425 - Adjust maxRequest constants to be used during tuning when values are not supplied

### DIFF
--- a/src/Outsystems.SetupTools/Lib/Constants.ps1
+++ b/src/Outsystems.SetupTools/Lib/Constants.ps1
@@ -96,19 +96,19 @@ $OSDotNetReqForMajor = @{
         Version              = '4.6.1'
         Value                = '394254'
         ToInstallVersion     = '4.7.2'
-        ToInstallDownloadURL = 'https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe'
+        ToInstallDownloadURL = 'https://download.visualstudio.microsoft.com/download/pr/1f5af042-d0e4-4002-9c59-9ba66bcf15f6/089f837de42708daacaae7c04b7494db/ndp472-kb4054530-x86-x64-allos-enu.exe'
     }
     '11' = @{
         Version              = '4.7.2'
         Value                = '461808'
         ToInstallVersion     = '4.7.2'
-        ToInstallDownloadURL = 'https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe'
+        ToInstallDownloadURL = 'https://download.visualstudio.microsoft.com/download/pr/1f5af042-d0e4-4002-9c59-9ba66bcf15f6/089f837de42708daacaae7c04b7494db/ndp472-kb4054530-x86-x64-allos-enu.exe'
     }
     '12' = @{
         Version              = '4.7.2'
         Value                = '461808'
         ToInstallVersion     = '4.7.2'
-        ToInstallDownloadURL = 'https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe'
+        ToInstallDownloadURL = 'https://download.visualstudio.microsoft.com/download/pr/1f5af042-d0e4-4002-9c59-9ba66bcf15f6/089f837de42708daacaae7c04b7494db/ndp472-kb4054530-x86-x64-allos-enu.exe'
     }
 }
 

--- a/src/Outsystems.SetupTools/Lib/Constants.ps1
+++ b/src/Outsystems.SetupTools/Lib/Constants.ps1
@@ -177,11 +177,11 @@ $OSIISConfig = @(
 
 # Performance Tuning
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
-$OSPerfTuningMaxRequestLength = 131072
+$OSPerfTuningMaxRequestLength = 262144
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
 [TimeSpan]$OSPerfTuningExecutionTimeout = '00:01:50'
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
-$OSPerfTuningMaxAllowedContentLength = 134217728
+$OSPerfTuningMaxAllowedContentLength = 268435456
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
 $OSPerfTuningMaxConnections = 4294967295
 

--- a/test/unit/Lib.Constants.Tests.ps1
+++ b/test/unit/Lib.Constants.Tests.ps1
@@ -7,7 +7,7 @@ Describe 'Lib Constants Tests' {
 
         $MajorVersion = '12'
         $SavePath = "$env:TEMP\dotnet12.exe"
-        $FileHash = 'C908F0A5BEA4BE282E35ACBA307D0061B71B8B66CA9894943D3CBB53CAD019BC'
+        $FileHash = '5CB624B97F9FD6D3895644C52231C9471CD88AACB57D6E198D3024A1839139F6'
 
         It 'Should have the right "Version"' { $script:OSDotNetReqForMajor[$MajorVersion]['Version'] | Should Be "4.7.2" }
         It 'Should have the right "Value"' { $script:OSDotNetReqForMajor[$MajorVersion]['Value'] | Should Be "461808" }
@@ -22,7 +22,7 @@ Describe 'Lib Constants Tests' {
 
         $MajorVersion = '11'
         $SavePath = "$env:TEMP\dotnet11.exe"
-        $FileHash = 'C908F0A5BEA4BE282E35ACBA307D0061B71B8B66CA9894943D3CBB53CAD019BC'
+        $FileHash = '5CB624B97F9FD6D3895644C52231C9471CD88AACB57D6E198D3024A1839139F6'
 
         It 'Should have the right "Version"' { $script:OSDotNetReqForMajor[$MajorVersion]['Version'] | Should Be "4.7.2" }
         It 'Should have the right "Value"' { $script:OSDotNetReqForMajor[$MajorVersion]['Value'] | Should Be "461808" }
@@ -37,7 +37,7 @@ Describe 'Lib Constants Tests' {
 
         $MajorVersion = '10'
         $SavePath = "$env:TEMP\dotnet10.exe"
-        $FileHash = 'C908F0A5BEA4BE282E35ACBA307D0061B71B8B66CA9894943D3CBB53CAD019BC'
+        $FileHash = '5CB624B97F9FD6D3895644C52231C9471CD88AACB57D6E198D3024A1839139F6'
 
         It 'Should have the right "Version"' { $script:OSDotNetReqForMajor[$MajorVersion]['Version'] | Should Be "4.6.1" }
         It 'Should have the right "Value"' { $script:OSDotNetReqForMajor[$MajorVersion]['Value'] | Should Be "394254" }


### PR DESCRIPTION
Changing the default values that are used when no specific values are supplied to the tuning scripts