### PR TITLE
RDMST-907 Removes SMS Connector Service

### DIFF
--- a/src/Outsystems.SetupTools/Lib/Constants.ps1
+++ b/src/Outsystems.SetupTools/Lib/Constants.ps1
@@ -4,8 +4,7 @@ $OSServices = @(
     "OutSystems Log Service",
     "OutSystems Deployment Controller Service",
     "OutSystems Deployment Service",
-    "OutSystems Scheduler Service",
-    "OutSystems SMS Connector Service"
+    "OutSystems Scheduler Service"
 )
 
 # Outsystems base Windows Features


### PR DESCRIPTION
We are currently removing SMS references from the O11 Platform Server. I noticed that Setup Tools has a reference to the legacy SMS Connector service so this PR intends to remove it.