### PR TITLE
R11PIT-846 Skip installing the .NET Core Runtime and the ASP.NET Runtime when installing the hosting bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# Outsystems.SetupTools Release History
+# OutSystems.SetupTools Release History
+
+## 3.16.2.0
+
+- Skip installing the .NET Core Runtime and the ASP.NET Runtime when installing the hosting bundle
 
 ## 3.16.1.0
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.16.1.{build}
+version: 3.16.2.{build}
 
 only_commits:
   files:

--- a/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
@@ -286,7 +286,7 @@ function Get-OSServerPreReqs
                                                                         foreach ($version in GetDotNetHostingBundleVersions)
                                                                         {
                                                                             # Check version 6.0
-                                                                            if (([version]$version).Major -eq 6 -and ([version]$version) -ge [version]$script:OSDotNetHostingBundleReq['6']['Version']) {
+                                                                            if (([version]$version).Major -eq 6 -and ([version]$version) -ge [version]$script:OSDotNetCoreHostingBundleReq['6']['Version']) {
                                                                                 $Status = $True
                                                                             }
                                                                         }

--- a/src/Outsystems.SetupTools/Lib/Constants.ps1
+++ b/src/Outsystems.SetupTools/Lib/Constants.ps1
@@ -125,11 +125,6 @@ $OSDotNetCoreHostingBundleReq = @{
         ToInstallDownloadURL = 'https://download.visualstudio.microsoft.com/download/pr/bdc70151-74f7-427c-a368-716d5f1840c5/6186889f6c784bae224eb15fb94c45fe/dotnet-hosting-3.1.14-win.exe'
         InstallerName = 'DotNetCore_WindowsHosting_31.exe'
     }
-}
-
-# .NET Hosting Bundle related
-[System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
-$OSDotNetHostingBundleReq = @{
     '6' = @{
         Version = '6.0.6'
         ToInstallDownloadURL = 'https://download.visualstudio.microsoft.com/download/pr/0d000d1b-89a4-4593-9708-eb5177777c64/cfb3d74447ac78defb1b66fd9b3f38e0/dotnet-hosting-6.0.6-win.exe'

--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -450,41 +450,7 @@ function InstallDotNetCoreHostingBundle([string]$MajorVersion, [string]$Sources)
     }
 
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Starting the installation"
-    $result = Start-Process -FilePath $installer -ArgumentList "/install", "/quiet", "/norestart" -Wait -PassThru -ErrorAction Stop
-
-    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returnig $($result.ExitCode)"
-
-    return $($result.ExitCode)
-}
-
-function InstallDotNetHostingBundle([string]$MajorVersion, [string]$Sources)
-{
-    if ($Sources)
-    {
-        if (Test-Path "$Sources\$($script:OSDotNetHostingBundleReq[$MajorVersion]['InstallerName'])")
-        {
-            $installer = "$Sources\$($script:OSDotNetHostingBundleReq[$MajorVersion]['InstallerName'])"
-            LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Using local file: $installer"
-        }
-        # If Windows is set to hide file extensions from file names, the file could have been stored with double extension by mistake.
-        elseif (Test-Path "$Sources\$($script:OSDotNetHostingBundleReq[$MajorVersion]['InstallerName']).exe")
-        {
-            $installer = "$($script:OSDotNetHostingBundleReq[$MajorVersion]['InstallerName']).exe"
-            LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Using local fallback file: $installer"
-        }
-        else {
-            throw [System.IO.FileNotFoundException] "$installerName.exe not found."
-        }
-    }
-    else
-    {
-        $installer = "$ENV:TEMP\$($script:OSDotNetHostingBundleReq[$MajorVersion]['InstallerName'])"
-        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Downloading sources from: $($script:OSDotNetHostingBundleReq[$MajorVersion]['ToInstallDownloadURL'])"
-        DownloadOSSources -URL $($script:OSDotNetHostingBundleReq[$MajorVersion]['ToInstallDownloadURL']) -SavePath $installer
-    }
-
-    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Starting the installation"
-    $result = Start-Process -FilePath $installer -ArgumentList "/install", "/quiet", "/norestart" -Wait -PassThru -ErrorAction Stop
+    $result = Start-Process -FilePath $installer -ArgumentList "OPT_NO_RUNTIME=1","OPT_NO_SHAREDFX=1","/install", "/quiet", "/norestart" -Wait -PassThru -ErrorAction Stop
 
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returnig $($result.ExitCode)"
 

--- a/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
+++ b/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
@@ -12,7 +12,7 @@
 RootModule = 'OutSystems.SetupTools.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.16.1.0'
+ModuleVersion = '3.16.2.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -21,13 +21,13 @@ ModuleVersion = '3.16.1.0'
 GUID = 'dcc020ea-a9c7-4bd3-91fc-e97432301020'
 
 # Author of this module
-Author = 'Pedro Nunes'
+Author = 'OutSystems'
 
 # Company or vendor of this module
 CompanyName = 'OutSystems'
 
 # Copyright statement for this module
-Copyright = '(c) 2018 OutSystems. All rights reserved.'
+Copyright = '(c) OutSystems. All rights reserved.'
 
 # Description of the functionality provided by this module
 Description = 'Tools for installing and manage the OutSystems platform installation'


### PR DESCRIPTION
### Description

In order to decrease the attack surface of the Platform we should not install unneeded components. These changes should be done on [GitHub - OutSystems/OutSystems.SetupTools: Powershell module to install and manage the OutSystems platform](https://github.com/OutSystems/OutSystems.SetupTools) repository and then bump the platform version in order for it to be used.

This fixes a vulnerability reported by [Tenable.io](http://tenable.io/) Scan Results: (.Net Test) Standard O11 FEs Scan when using outdated hosting bundles

### Acceptance Criteria

The following arguments should be passed to the .net hosting bundle installer:

OPT_NO_RUNTIME=1: Skip installing the .NET Core runtime. Used when the server only hosts [self-contained deployments (SCD)](https://docs.microsoft.com/en-us/dotnet/core/deploying/#self-contained-deployments-scd).

OPT_NO_SHAREDFX=1: Skip installing the [ASP.NET](http://asp.net/) Shared Framework ([ASP.NET](http://asp.net/) runtime). Used when the server only hosts [self-contained deployments (SCD)](https://docs.microsoft.com/en-us/dotnet/core/deploying/#self-contained-deployments-scd).