### PR TITLE
R11PIT-846 Implement flag to uninstall previous .NET Core packages and skip the installation of the .NET Core Runtime and the ASP.NET Runtime when installing the hosting bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 3.16.2.0
 
 - Implement flag to uninstall previous .NET Core packages when installing the hosting bundle
-- Implement flag to skip the installation of the .NET Core Runtime and the ASP.NET Runtime when installing the hosting bundle 
+- Implement flag to skip the installation of the .NET Core Runtime and the ASP.NET Runtime when installing the hosting bundle
+
 ## 3.16.1.0
 
 - Adapt build script for new Service Studio installer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.16.2.0
 
-- Skip installing the .NET Core Runtime and the ASP.NET Runtime when installing the hosting bundle
+- Implement flag to uninstall previous .NET Core packages and skip the installation of the .NET Core Runtime and the ASP.NET Runtime when installing the hosting bundle
 
 ## 3.16.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 3.16.2.0
 
-- Implement flag to uninstall previous .NET Core packages and skip the installation of the .NET Core Runtime and the ASP.NET Runtime when installing the hosting bundle
-
+- Implement flag to uninstall previous .NET Core packages when installing the hosting bundle
+- Implement flag to skip the installation of the .NET Core Runtime and the ASP.NET Runtime when installing the hosting bundle 
 ## 3.16.1.0
 
 - Adapt build script for new Service Studio installer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# Outsystems.SetupTools Release History
+# OutSystems.SetupTools Release History
+
+## 3.16.2.0
+
+- Skip installing the .NET Core Runtime and the ASP.NET Runtime when installing the hosting bundle
 
 ## 3.16.1.0
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.16.1.{build}
+version: 3.16.2.{build}
 
 only_commits:
   files:

--- a/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
@@ -286,7 +286,7 @@ function Get-OSServerPreReqs
                                                                         foreach ($version in GetDotNetHostingBundleVersions)
                                                                         {
                                                                             # Check version 6.0
-                                                                            if (([version]$version).Major -eq 6 -and ([version]$version) -ge [version]$script:OSDotNetHostingBundleReq['6']['Version']) {
+                                                                            if (([version]$version).Major -eq 6 -and ([version]$version) -ge [version]$script:OSDotNetCoreHostingBundleReq['6']['Version']) {
                                                                                 $Status = $True
                                                                             }
                                                                         }

--- a/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
@@ -27,9 +27,8 @@ function Install-OSServerPreReqs
     .PARAMETER SourcePath
     Specifies a local path having the pre-requisites binaries.
 
-    .PARAMETER SkipRuntime
-    Specifies whether the installer should skip the installation of .NET Core Runtime and the ASP.NET Runtime.
-    Note: This also removes previous installations of .NET Core Runtime and the ASP.NET Runtime.
+    .PARAMETER OnlyMostRecentHostingBundlePackage
+    Specifies whether the installer should skip the installation of .NET Core Runtime and the ASP.NET Runtime and remove previous installations of the Hosting Bundle.
     Accepted values: $false and $true. By default this is set to $false.
 
     .EXAMPLE
@@ -71,7 +70,7 @@ function Install-OSServerPreReqs
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [string]$SkipRuntime = "0"
+        [string]$OnlyMostRecentHostingBundlePackage = "0"
     )
 
     begin
@@ -463,8 +462,8 @@ function Install-OSServerPreReqs
         {
             try
             {
-                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Installing .NET 6.0 Windows Server Hosting bundle - SkipRuntime $SkipRuntime"
-                $exitCode = InstallDotNetCoreHostingBundle -MajorVersion '6' -Sources $SourcePath -SkipRuntime $SkipRuntime
+                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Installing .NET 6.0 Windows Server Hosting bundle"
+                $exitCode = InstallDotNetCoreHostingBundle -MajorVersion '6' -Sources $SourcePath -OnlyMostRecentHostingBundlePackage $OnlyMostRecentHostingBundlePackage
             }
             catch [System.IO.FileNotFoundException]
             {
@@ -516,7 +515,7 @@ function Install-OSServerPreReqs
             }
         }
 
-        if ($mostRecentHostingBundleVersion -and $SkipRuntime -eq "1")
+        if ($mostRecentHostingBundleVersion -and $OnlyMostRecentHostingBundlePackage -eq "1")
         {
             $isInstalled = IsDotNetCoreUninstallToolInstalled
             if (-not $isInstalled)
@@ -551,7 +550,7 @@ function Install-OSServerPreReqs
             }
             else
             {
-                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message ".NET Uninstall Tool already installed"
+                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message ".NET Uninstall Tool found"
             }
 
             $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")

--- a/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
@@ -69,8 +69,7 @@ function Install-OSServerPreReqs
         [string]$PatchVersion = "0",
 
         [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [string]$OnlyMostRecentHostingBundlePackage = "0"
+        [bool]$OnlyMostRecentHostingBundlePackage = $false
     )
 
     begin
@@ -515,7 +514,7 @@ function Install-OSServerPreReqs
             }
         }
 
-        if ($mostRecentHostingBundleVersion -and $OnlyMostRecentHostingBundlePackage -eq "1")
+        if ($mostRecentHostingBundleVersion -and $OnlyMostRecentHostingBundlePackage)
         {
             $isInstalled = IsDotNetCoreUninstallToolInstalled
             if (-not $isInstalled)

--- a/src/Outsystems.SetupTools/Lib/AppManagement.ps1
+++ b/src/Outsystems.SetupTools/Lib/AppManagement.ps1
@@ -101,7 +101,7 @@ function AppMgmt_GetPublishResults([string]$SCHost, [int]$PublishId, [pscredenti
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Errors count: $($resultsCount.Errors)"
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Warnings count: $($resultsCount.Warnings)"
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "LastMessageId: $($resultsCount.LastMessageId)"
-    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Returnig publish results"
+    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Returning publish results"
 
     # Return results. The calling function should know what to do with this
     return $resultsCount

--- a/src/Outsystems.SetupTools/Lib/Common.ps1
+++ b/src/Outsystems.SetupTools/Lib/Common.ps1
@@ -296,13 +296,13 @@ function TestFileLock([string]$Path)
         if ($stream) {
             LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Sucessfully open the file. File is not locked"
             $stream.Close()
-            LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Closing and returnig false"
+            LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Closing and Returning false"
         }
         return $false
     }
     catch
     {
-        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "File is locked!!! Returnig true!!"
+        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "File is locked!!! Returning true!!"
         return $true
     }
 }
@@ -321,7 +321,7 @@ function DecryptSetting([string]$Setting)
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Decrypting setting $Setting"
     $decryptedSetting = [OutSystems.HubEdition.RuntimePlatform.Settings]::DecryptString($Setting)
 
-    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Returnig $decryptedSetting"
+    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Returning $decryptedSetting"
 
     return $decryptedSetting
 }
@@ -331,7 +331,7 @@ function EncryptSetting([string]$Setting)
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Encrypting setting $Setting"
     $encryptedSetting = [OutSystems.HubEdition.RuntimePlatform.Settings]::EncryptString($Setting)
 
-    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Returnig $encryptedSetting"
+    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Returning $encryptedSetting"
 
     return $encryptedSetting
 }

--- a/src/Outsystems.SetupTools/Lib/Constants.ps1
+++ b/src/Outsystems.SetupTools/Lib/Constants.ps1
@@ -125,11 +125,6 @@ $OSDotNetCoreHostingBundleReq = @{
         ToInstallDownloadURL = 'https://download.visualstudio.microsoft.com/download/pr/bdc70151-74f7-427c-a368-716d5f1840c5/6186889f6c784bae224eb15fb94c45fe/dotnet-hosting-3.1.14-win.exe'
         InstallerName = 'DotNetCore_WindowsHosting_31.exe'
     }
-}
-
-# .NET Hosting Bundle related
-[System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
-$OSDotNetHostingBundleReq = @{
     '6' = @{
         Version = '6.0.6'
         ToInstallDownloadURL = 'https://download.visualstudio.microsoft.com/download/pr/0d000d1b-89a4-4593-9708-eb5177777c64/cfb3d74447ac78defb1b66fd9b3f38e0/dotnet-hosting-6.0.6-win.exe'

--- a/src/Outsystems.SetupTools/Lib/Constants.ps1
+++ b/src/Outsystems.SetupTools/Lib/Constants.ps1
@@ -136,7 +136,7 @@ $OSDotNetCoreHostingBundleReq = @{
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
 $OSDotNetCoreUninstallReq = @{
     '1.5' = @{
-        Version = ''
+        Version = '1.5.255402'
         ToInstallDownloadURL = 'https://github.com/dotnet/cli-lab/releases/download/1.5.255402/dotnet-core-uninstall-1.5.255402.msi'
         InstallerName = 'DotNetCore_Uninstall_15.msi'
     }

--- a/src/Outsystems.SetupTools/Lib/Constants.ps1
+++ b/src/Outsystems.SetupTools/Lib/Constants.ps1
@@ -132,6 +132,16 @@ $OSDotNetCoreHostingBundleReq = @{
     }
 }
 
+# .NET Core Uninstall Tool related
+[System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
+$OSDotNetCoreUninstallReq = @{
+    '1.5' = @{
+        Version = ''
+        ToInstallDownloadURL = 'https://github.com/dotnet/cli-lab/releases/download/1.5.255402/dotnet-core-uninstall-1.5.255402.msi'
+        InstallerName = 'DotNetCore_Uninstall_15.msi'
+    }
+}
+
 # Database default timeout
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
 $OSDBTimeout = "60"

--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -423,7 +423,7 @@ function InstallBuildTools([string]$Sources)
     return $($result.ExitCode)
 }
 
-function InstallDotNetCoreHostingBundle([string]$MajorVersion, [string]$Sources, [string]$SkipRuntime)
+function InstallDotNetCoreHostingBundle([string]$MajorVersion, [string]$Sources, [string]$OnlyMostRecentHostingBundlePackage)
 {
     if ($Sources)
     {
@@ -452,7 +452,7 @@ function InstallDotNetCoreHostingBundle([string]$MajorVersion, [string]$Sources,
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Starting the installation"
 
 
-    if ($SkipRuntime -eq "1") {
+    if ($OnlyMostRecentHostingBundlePackage -eq "1") {
         $result = Start-Process -FilePath $installer -ArgumentList "OPT_NO_RUNTIME=1","OPT_NO_SHAREDFX=1","/install", "/quiet", "/norestart" -Wait -PassThru -ErrorAction Stop
         LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returnig $($result.ExitCode)"
         return $($result.ExitCode)

--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -450,41 +450,7 @@ function InstallDotNetCoreHostingBundle([string]$MajorVersion, [string]$Sources)
     }
 
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Starting the installation"
-    $result = Start-Process -FilePath $installer -ArgumentList "/install", "/quiet", "/norestart" -Wait -PassThru -ErrorAction Stop
-
-    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returnig $($result.ExitCode)"
-
-    return $($result.ExitCode)
-}
-
-function InstallDotNetHostingBundle([string]$MajorVersion, [string]$Sources)
-{
-    if ($Sources)
-    {
-        if (Test-Path "$Sources\$($script:OSDotNetHostingBundleReq[$MajorVersion]['InstallerName'])")
-        {
-            $installer = "$Sources\$($script:OSDotNetHostingBundleReq[$MajorVersion]['InstallerName'])"
-            LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Using local file: $installer"
-        }
-        # If Windows is set to hide file extensions from file names, the file could have been stored with double extension by mistake.
-        elseif (Test-Path "$Sources\$($script:OSDotNetHostingBundleReq[$MajorVersion]['InstallerName']).exe")
-        {
-            $installer = "$($script:OSDotNetHostingBundleReq[$MajorVersion]['InstallerName']).exe"
-            LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Using local fallback file: $installer"
-        }
-        else {
-            throw [System.IO.FileNotFoundException] "$installerName.exe not found."
-        }
-    }
-    else
-    {
-        $installer = "$ENV:TEMP\$($script:OSDotNetHostingBundleReq[$MajorVersion]['InstallerName'])"
-        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Downloading sources from: $($script:OSDotNetHostingBundleReq[$MajorVersion]['ToInstallDownloadURL'])"
-        DownloadOSSources -URL $($script:OSDotNetHostingBundleReq[$MajorVersion]['ToInstallDownloadURL']) -SavePath $installer
-    }
-
-    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Starting the installation"
-    $result = Start-Process -FilePath $installer -ArgumentList "/install", "/quiet", "/norestart" -Wait -PassThru -ErrorAction Stop
+    $result = Start-Process -FilePath $installer -ArgumentList "OPT_NO_RUNTIME=1","OPT_NO_SHAREDFX=1","/install", "/quiet", "/norestart" -Wait -PassThru -ErrorAction Stop
 
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returnig $($result.ExitCode)"
 

--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -423,7 +423,7 @@ function InstallBuildTools([string]$Sources)
     return $($result.ExitCode)
 }
 
-function InstallDotNetCoreHostingBundle([string]$MajorVersion, [string]$Sources, [bool]$OnlyMostRecentHostingBundlePackage)
+function InstallDotNetCoreHostingBundle([string]$MajorVersion, [string]$Sources, [bool]$SkipRuntimePackages)
 {
     if ($Sources)
     {
@@ -451,16 +451,15 @@ function InstallDotNetCoreHostingBundle([string]$MajorVersion, [string]$Sources,
 
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Starting the installation"
 
-    if ($OnlyMostRecentHostingBundlePackage) {
+    if ($SkipRuntimePackages) {
         $result = Start-Process -FilePath $installer -ArgumentList "OPT_NO_RUNTIME=1","OPT_NO_SHAREDFX=1","/install", "/quiet", "/norestart" -Wait -PassThru -ErrorAction Stop
-        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returning $($result.ExitCode)"
-        return $($result.ExitCode)
     }
     else {
         $result = Start-Process -FilePath $installer -ArgumentList "/install", "/quiet", "/norestart" -Wait -PassThru -ErrorAction Stop
-        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returning $($result.ExitCode)"
-        return $($result.ExitCode)
     }
+
+    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returning $($result.ExitCode)"
+    return $($result.ExitCode)
 }
 
 function InstallDotNetCoreUninstallTool([string]$MajorVersion, [string]$Sources)
@@ -545,6 +544,18 @@ function UninstallPreviousDotNetCorePackages([string]$Package, [string]$RecentVe
     }
 
     return $false
+}
+
+function LogErrorMessage([pscustomobject]$InstallResult, [string]$Message)
+{
+    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Exception $_.Exception -Stream 3 -Message $Message
+    WriteNonTerminalError -Message $Message
+
+    $installResult.Success = $false
+    $installResult.ExitCode = -1
+    $installResult.Message = $Message
+
+    return $installResult
 }
 
 function InstallErlang([string]$InstallDir, [string]$Sources)

--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -423,7 +423,7 @@ function InstallBuildTools([string]$Sources)
     return $($result.ExitCode)
 }
 
-function InstallDotNetCoreHostingBundle([string]$MajorVersion, [string]$Sources, [string]$OnlyMostRecentHostingBundlePackage)
+function InstallDotNetCoreHostingBundle([string]$MajorVersion, [string]$Sources, [bool]$OnlyMostRecentHostingBundlePackage)
 {
     if ($Sources)
     {
@@ -452,7 +452,7 @@ function InstallDotNetCoreHostingBundle([string]$MajorVersion, [string]$Sources,
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Starting the installation"
 
 
-    if ($OnlyMostRecentHostingBundlePackage -eq "1") {
+    if ($OnlyMostRecentHostingBundlePackage) {
         $result = Start-Process -FilePath $installer -ArgumentList "OPT_NO_RUNTIME=1","OPT_NO_SHAREDFX=1","/install", "/quiet", "/norestart" -Wait -PassThru -ErrorAction Stop
         LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returnig $($result.ExitCode)"
         return $($result.ExitCode)

--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -451,24 +451,20 @@ function InstallDotNetCoreHostingBundle([string]$MajorVersion, [string]$Sources,
 
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Starting the installation"
 
-
     if ($OnlyMostRecentHostingBundlePackage) {
         $result = Start-Process -FilePath $installer -ArgumentList "OPT_NO_RUNTIME=1","OPT_NO_SHAREDFX=1","/install", "/quiet", "/norestart" -Wait -PassThru -ErrorAction Stop
-        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returnig $($result.ExitCode)"
+        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returning $($result.ExitCode)"
         return $($result.ExitCode)
     }
     else {
         $result = Start-Process -FilePath $installer -ArgumentList "/install", "/quiet", "/norestart" -Wait -PassThru -ErrorAction Stop
-        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returnig $($result.ExitCode)"
+        LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returning $($result.ExitCode)"
         return $($result.ExitCode)
     }
 }
 
 function InstallDotNetCoreUninstallTool([string]$MajorVersion, [string]$Sources)
 {
-    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Reached here with major: $MajorVersion and $Sources"
-    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Path: $Sources\$($script:OSDotNetCoreUninstallReq[$MajorVersion]['InstallerName'])"
-
     if ($Sources)
     {
         if (Test-Path "$Sources\$($script:OSDotNetCoreUninstallReq[$MajorVersion]['InstallerName'])")
@@ -496,7 +492,7 @@ function InstallDotNetCoreUninstallTool([string]$MajorVersion, [string]$Sources)
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Starting the installation"
 
     $result = Start-Process -FilePath $installer -ArgumentList "/quiet", "/norestart" -Wait -PassThru -ErrorAction Stop
-    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returnig $($result.ExitCode)"
+    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returning $($result.ExitCode)"
     return $($result.ExitCode)
 }
 
@@ -557,7 +553,7 @@ function InstallErlang([string]$InstallDir, [string]$Sources)
 
     $result = Start-Process -FilePath $Sources -ArgumentList "/S", "/D=$InstallDir" -Wait -PassThru -ErrorAction Stop
 
-    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returnig $($result.ExitCode)"
+    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Installation finished. Returning $($result.ExitCode)"
 
     return $($result.ExitCode)
 }
@@ -975,7 +971,7 @@ function GenerateEncryptKey()
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Generating a new encrypted key"
     $key = [OutSystems.HubEdition.RuntimePlatform.NewRuntime.Authentication.Keys]::GenerateEncryptKey()
 
-    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Returnig $key"
+    LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Returning $key"
 
     return $key
 }

--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -514,7 +514,7 @@ function IsDotNetCoreUninstallToolInstalled()
 
 function UninstallPreviousDotNetCorePackages([string]$Package, [string]$RecentVersion)
 {
-    Write-Output "y" | dotnet-core-uninstall remove --all-but $mostRecentHostingBundleVersion $Package
+    Write-Output "y" | dotnet-core-uninstall remove --all-but $mostRecentHostingBundleVersion $Package | Out-Null
 
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Checking if registry key of previous .NET Core versions exists in HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
 

--- a/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
+++ b/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
@@ -12,7 +12,7 @@
 RootModule = 'OutSystems.SetupTools.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.16.1.0'
+ModuleVersion = '3.16.2.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -21,13 +21,13 @@ ModuleVersion = '3.16.1.0'
 GUID = 'dcc020ea-a9c7-4bd3-91fc-e97432301020'
 
 # Author of this module
-Author = 'Pedro Nunes'
+Author = 'OutSystems'
 
 # Company or vendor of this module
 CompanyName = 'OutSystems'
 
 # Copyright statement for this module
-Copyright = '(c) 2018 OutSystems. All rights reserved.'
+Copyright = '(c) OutSystems. All rights reserved.'
 
 # Description of the functionality provided by this module
 Description = 'Tools for installing and manage the OutSystems platform installation'

--- a/test/unit/Install-OSServerPreReqs.Tests.ps1
+++ b/test/unit/Install-OSServerPreReqs.Tests.ps1
@@ -1259,9 +1259,9 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '1' -ErrorVariable err -ErrorAction SilentlyContinue } | Should Not throw }
         }
 
-        Context 'When trying to install prerequisites for a OS 11 version in Minor version 17 and Patch version newer than 1 (11.17.2) with SkipRuntime set to True' {
+        Context 'When trying to install prerequisites for a OS 11 version in Minor version 17 and Patch version newer than 1 (11.17.2) with OnlyMostRecentHostingBundlePackage flag active' {
 
-            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '2' -SkipRuntime '1' -ErrorVariable err -ErrorAction SilentlyContinue
+            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '2' -OnlyMostRecentHostingBundlePackage '1' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
             It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
@@ -1285,9 +1285,9 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '2' -ErrorVariable err -ErrorAction SilentlyContinue } | Should Not throw }
         }
 
-        Context 'When trying to install prerequisites for a OS 11 version in Minor version 17 and Patch version older than 1 (11.17.0) with SkipRuntime set to True' {
+        Context 'When trying to install prerequisites for a OS 11 version in Minor version 17 and Patch version older than 1 (11.17.0) with OnlyMostRecentHostingBundlePackage flag active' {
 
-            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '0' -SkipRuntime '1' -ErrorVariable err -ErrorAction SilentlyContinue
+            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '0' -OnlyMostRecentHostingBundlePackage '1' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
             It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
@@ -1311,9 +1311,9 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '0' -ErrorVariable err -ErrorAction SilentlyContinue } | Should Not throw }
         }
 
-        Context 'When trying to install prerequisites for a OS 11 version in Minor version 17 and Patch version 1 (11.17.1) with SkipRuntime set to True' {
+        Context 'When trying to install prerequisites for a OS 11 version in Minor version 17 and Patch version 1 (11.17.1) with OnlyMostRecentHostingBundlePackage flag active' {
 
-            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '1' -SkipRuntime '1' -ErrorVariable err -ErrorAction SilentlyContinue
+            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '1' -OnlyMostRecentHostingBundlePackage '1' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
             It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
@@ -1363,9 +1363,9 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue } | Should Not throw }
         }
 
-        Context 'When trying to install prerequisites for a OS 11 version without passing the optional Minor and Patch Versions, but with SkipRuntime set to True' {
+        Context 'When trying to install prerequisites for a OS 11 version without passing the optional Minor and Patch Versions and with OnlyMostRecentHostingBundlePackage flag active' {
 
-            $result = Install-OSServerPreReqs -MajorVersion '11' -SkipRuntime '1' -ErrorVariable err -ErrorAction SilentlyContinue
+            $result = Install-OSServerPreReqs -MajorVersion '11' -OnlyMostRecentHostingBundlePackage '1' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
             It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }

--- a/test/unit/Install-OSServerPreReqs.Tests.ps1
+++ b/test/unit/Install-OSServerPreReqs.Tests.ps1
@@ -1261,7 +1261,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
         Context 'When trying to install prerequisites for a OS 11 version in Minor version 17 and Patch version newer than 1 (11.17.2) with OnlyMostRecentHostingBundlePackage flag active' {
 
-            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '2' -OnlyMostRecentHostingBundlePackage '1' -ErrorVariable err -ErrorAction SilentlyContinue
+            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '2' -OnlyMostRecentHostingBundlePackage $true -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
             It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
@@ -1287,7 +1287,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
         Context 'When trying to install prerequisites for a OS 11 version in Minor version 17 and Patch version older than 1 (11.17.0) with OnlyMostRecentHostingBundlePackage flag active' {
 
-            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '0' -OnlyMostRecentHostingBundlePackage '1' -ErrorVariable err -ErrorAction SilentlyContinue
+            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '0' -OnlyMostRecentHostingBundlePackage $true -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
             It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
@@ -1313,7 +1313,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
         Context 'When trying to install prerequisites for a OS 11 version in Minor version 17 and Patch version 1 (11.17.1) with OnlyMostRecentHostingBundlePackage flag active' {
 
-            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '1' -OnlyMostRecentHostingBundlePackage '1' -ErrorVariable err -ErrorAction SilentlyContinue
+            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '1' -OnlyMostRecentHostingBundlePackage $true -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
             It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
@@ -1365,7 +1365,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
         Context 'When trying to install prerequisites for a OS 11 version without passing the optional Minor and Patch Versions and with OnlyMostRecentHostingBundlePackage flag active' {
 
-            $result = Install-OSServerPreReqs -MajorVersion '11' -OnlyMostRecentHostingBundlePackage '1' -ErrorVariable err -ErrorAction SilentlyContinue
+            $result = Install-OSServerPreReqs -MajorVersion '11' -OnlyMostRecentHostingBundlePackage $true -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
             It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }


### PR DESCRIPTION
### Description

This PR is related to [R11PIT-846](https://outsystemsrd.atlassian.net/browse/R11PIT-846). 

In order to decrease the attack surface of the Platform we should not install unneeded components. These changes should be done on [GitHub - OutSystems/OutSystems.SetupTools: Powershell module to install and manage the OutSystems platform](https://github.com/OutSystems/OutSystems.SetupTools) repository and then bump the platform version in order for it to be used.

This fixes a vulnerability reported by [Tenable.io](http://tenable.io/) Scan Results: (.Net Test) Standard O11 FEs Scan when using outdated hosting bundles.

A new flag was implemented in order to skip the installation of ASP.NET and .NET (Core) Runtime packages in newer installations and remove previous Hosting Bundle packages (also including ASP.NET and .NET (Core) Runtime) when the flag is active.

To do this, we added a new dependency to the [.NET Uninstall Tool](https://learn.microsoft.com/en-us/dotnet/core/additional-tools/uninstall-tool?tabs=windows), which is the official tool recommended by Microsoft to uninstall the previous .NET  packages.

This change will allow the new Platform Server installer to set a new flag that, when active, will utilize this new implemented behavior.

Furthermore, there was also a cleanup of [code merged in this PR](https://github.com/OutSystems/OutSystems.SetupTools/commit/16501b149485b0bd8fb504c3da1560eb5fa38e1c) in order to centralize the places where changes are needed in future hosting bundle upgrades (this cleanup was suggested and started by @smeegoan).

### Acceptance Criteria

- [x] Implement new flag in the pre-requisites installation script

- [x] When flag is active, installer skips the installation of .NET Core Runtime and the ASP.NET Runtime

- [x] When flag is active, installer should remove all previous .NET (Core) installations (including .NET Core Runtime and the ASP.NET Runtime packages)