### PR TITLE
R11OT-531 Changed setup to include CentralizedPlatformLogs extension

### DIFF
--- a/src/Outsystems.SetupTools/Functions/Install-OSPlatformServiceCenter.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSPlatformServiceCenter.ps1
@@ -90,7 +90,14 @@ function Install-OSPlatformServiceCenter
                 }
                 { ($_  -as [int]) -ge 11}
                 {
-                    $scInstallerArguments = '-file ServiceCenter.oml -extension OMLProcessor.xif IntegrationStudio.xif PlatformLogs.xif'
+                    if (($(([version]$osVersion).Minor) -lt 18) -or ($(([version]$osVersion).Minor) -eq 18 -and $(([version]$osVersion).Build) -lt 1))
+                    {
+                        $scInstallerArguments = '-file ServiceCenter.oml -extension OMLProcessor.xif IntegrationStudio.xif PlatformLogs.xif'
+                    }
+                    else
+                    {
+                        $scInstallerArguments = '-file ServiceCenter.oml -extension OMLProcessor.xif IntegrationStudio.xif CentralizedPlatformLogs.xif'
+                    }
                 }
                 default
                 {


### PR DESCRIPTION
More specifically, changed `Install-OSPlatformServiceCenter` to separate between the `PlatformLogs` and `CentralizedPlatformLogs` extensions depending on the minor version.

I set the cutoff point to version `11.18.1`, which is the minimum version required for `CentralizedPlatformLogs` ([source](https://outsystemsrd.atlassian.net/wiki/spaces/RDOO/pages/3370583977/How+to+use+Centralized+Platform+Logs+extension#Requirements)), but I am uncertain of whether this is the correct version to choose, and would appreciate any reviewers to help me clarify that. ✌️:pray: