### PR TITLE
Exclude Server.API and Server.Identity from being moved to another app pool.

### DIFF
--- a/src/Outsystems.SetupTools/Functions/Set-OSServerPerformanceTunning.ps1
+++ b/src/Outsystems.SetupTools/Functions/Set-OSServerPerformanceTunning.ps1
@@ -129,7 +129,7 @@ function Set-OSServerPerformanceTunning
             # Build an array with all matching Apps.
             foreach ($appMatchPattern in $($Config.Match))
             {
-                $interestingApps += $DefaultWebSiteApps | Where-Object -FilterScript { $_ -like $appMatchPattern }
+                $interestingApps += $DefaultWebSiteApps | Where-Object -FilterScript { ($_ -like $appMatchPattern) -and ($_ -notin $OSIISConfigExcludedApps) }
             }
 
             # if an app was found

--- a/src/Outsystems.SetupTools/Functions/Set-OSServerPerformanceTunning2.ps1
+++ b/src/Outsystems.SetupTools/Functions/Set-OSServerPerformanceTunning2.ps1
@@ -253,7 +253,7 @@ function Set-OSServerPerformanceTunning2
                     # Build an array with all matching Apps.
                     foreach ($appMatchPattern in $($Config.Match))
                     {
-                        $interestingApps += $DefaultWebSiteApps | Where-Object -FilterScript { $_ -like $appMatchPattern }
+                        $interestingApps += $DefaultWebSiteApps | Where-Object -FilterScript { ($_ -like $appMatchPattern) -and ($_ -notin $OSIISConfigExcludedApps) }
                     }
                 }
 

--- a/src/Outsystems.SetupTools/Lib/Constants.ps1
+++ b/src/Outsystems.SetupTools/Lib/Constants.ps1
@@ -189,6 +189,8 @@ $OSIISConfig = @(
         'Match'            = @('/LT*', '/lifet*', '/LifeT*', 'PerformanceMonitor')
     }
 )
+[System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
+$OSIISConfigExcludedApps = ( '/server.api', '/server.identity' )
 
 # Performance Tuning
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]


### PR DESCRIPTION
Exclude Server.API and Server.Identity IIS apps from being moved to the OutSystemsApplications app pool by Set-OSServerPerformanceTunning and Set-OSServerPerformanceTunning2.

Fixes #111 .