### PR TITLE
Improve Get-OSRepoAvailableVersions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ install:
       Install-Module psake -Scope CurrentUser -Force -RequiredVersion 4.7.4
       Install-Module PSScriptAnalyzer -Scope CurrentUser -Force
       Install-Module platyPS -Scope CurrentUser -Force
+      Uninstall-Module AzureRM -Force
       Install-Module Az.Storage -Scope CurrentUser -Force -AllowClobber
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ install:
       Install-Module psake -Scope CurrentUser -Force -RequiredVersion 4.7.4
       Install-Module PSScriptAnalyzer -Scope CurrentUser -Force
       Install-Module platyPS -Scope CurrentUser -Force
+      Install-Module Az.Storage -Scope CurrentUser -Force -AllowClobber
 
 build_script:
     - ps: |

--- a/src/Outsystems.SetupTools/Functions/Get-OSRepoAvailableVersions.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSRepoAvailableVersions.ps1
@@ -75,27 +75,27 @@ function Get-OSRepoAvailableVersions
             'PlatformServer'
             {
                 $AppFiles = $RepoFiles | Where-Object -FilterScript { $_ -like "PlatformServer-*" }
-                $AppVersions_Strings = $AppFiles -replace 'PlatformServer-', '' -replace '.exe', ''
+                $AppVersions_Strings = $AppFiles -replace 'PlatformServer-', '' -replace '(?<=\d+\.\d+\.\d+\.\d+)\D.*exe', ''
             }
             'Lifetime'
             {
                 $AppFiles = $RepoFiles | Where-Object -FilterScript { $_ -like "LifeTimeWithPlatformServer-*" }
-                $AppVersions_Strings = $AppFiles -replace 'LifeTimeWithPlatformServer-', '' -replace '.exe', ''
+                $AppVersions_Strings = $AppFiles -replace 'LifeTimeWithPlatformServer-', '' -replace '(?<=\d+\.\d+\.\d+\.\d+)\D.*exe', ''
             }
             'DevelopmentEnvironment'
             {
                 $AppFiles = $RepoFiles | Where-Object -FilterScript { $_ -like "DevelopmentEnvironment-*" }
-                $AppVersions_Strings = $AppFiles -replace 'DevelopmentEnvironment-', '' -replace '.exe', ''
+                $AppVersions_Strings = $AppFiles -replace 'DevelopmentEnvironment-', '' -replace '(?<=\d+\.\d+\.\d+\.\d+)\D.*exe', ''
             }
             'ServiceStudio'
             {
                 $AppFiles = $RepoFiles | Where-Object -FilterScript { $_ -like "ServiceStudio-*" }
-                $AppVersions_Strings = $AppFiles -replace 'ServiceStudio-', '' -replace '.exe', ''
+                $AppVersions_Strings = $AppFiles -replace 'ServiceStudio-', '' -replace '(?<=\d+\.\d+\.\d+\.\d+)\D.*exe', ''
             }
             'IntegrationStudio'
             {
                 $AppFiles = $RepoFiles | Where-Object -FilterScript { $_ -like "IntegrationStudio-*" }
-                $AppVersions_Strings = $AppFiles -replace 'IntegrationStudio-', '' -replace '.exe', ''
+                $AppVersions_Strings = $AppFiles -replace 'IntegrationStudio-', '' -replace '(?<=\d+\.\d+\.\d+\.\d+)\D.*exe', ''
             }
         }
 

--- a/src/Outsystems.SetupTools/Functions/Get-OSRepoAvailableVersions.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSRepoAvailableVersions.ps1
@@ -102,15 +102,19 @@ function Get-OSRepoAvailableVersions
         # Filter only major version and sort desc
         $AppVersions = [System.Version[]]($AppVersions_Strings | Where-Object -FilterScript { $_ -like "$MajorVersion.*" }) | Sort-Object -Descending
 
-        if ($Latest.IsPresent)
+        if ( ($AppVersions.Count -gt 0) -and $Latest.IsPresent)
         {
             LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Returning the latest version"
             return $AppVersions[0].ToString()
         }
-        else
+        elseif ($AppVersions.Count -gt 0)
         {
             LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Returning $($AppVersions.Count) versions"
             return $AppVersions | ForEach-Object -Process { $_.ToString() }
+        }
+        else {
+            LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "No versions returned."
+            return $null
         }
     }
 

--- a/src/Outsystems.SetupTools/Functions/Get-OSRepoAvailableVersions.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSRepoAvailableVersions.ps1
@@ -10,7 +10,7 @@ function Get-OSRepoAvailableVersions
 
     .PARAMETER Application
     Specifies which application to retrieve the version
-    This can be 'PlatformServer', 'ServiceStudio', 'Lifetime'
+    This can be 'PlatformServer', 'Lifetime', 'DevelopmentEnvironment', 'ServiceStudio', 'IntegrationStudio'
 
     .PARAMETER MajorVersion
     Specifies the platform major version
@@ -24,7 +24,7 @@ function Get-OSRepoAvailableVersions
     Get-OSRepoAvailableVersions -Application 'PlatformServer' -MajorVersion '10'
 
     .EXAMPLE
-    Get the latest available version of the OutSystems 11 development environment
+    Get the latest available version of the OutSystems 11 Service Studio
     Get-OSRepoAvailableVersions -Application 'ServiceStudio' -MajorVersion '11' -Latest
 
     #>
@@ -33,7 +33,7 @@ function Get-OSRepoAvailableVersions
     [OutputType('String')]
     param (
         [Parameter(Mandatory = $true)]
-        [ValidateSet('PlatformServer', 'ServiceStudio', 'Lifetime')]
+        [ValidateSet('PlatformServer', 'Lifetime', 'DevelopmentEnvironment', 'ServiceStudio', 'IntegrationStudio')]
         [string]$Application,
 
         [Parameter(Mandatory = $true)]
@@ -59,7 +59,7 @@ function Get-OSRepoAvailableVersions
 
         try
         {
-            $files = GetAzStorageFileList
+            $RepoFiles = GetAzStorageFileList
         }
         catch
         {
@@ -74,33 +74,43 @@ function Get-OSRepoAvailableVersions
         {
             'PlatformServer'
             {
-                $files = $files | Where-Object -FilterScript { $_ -like "PlatformServer-*" }
-                $versions = $files -replace 'PlatformServer-', '' -replace '.exe', ''
-            }
-            'ServiceStudio'
-            {
-                $files = $files | Where-Object -FilterScript { $_ -like "DevelopmentEnvironment-*" }
-                $versions = $files -replace 'DevelopmentEnvironment-', '' -replace '.exe', ''
+                $AppFiles = $RepoFiles | Where-Object -FilterScript { $_ -like "PlatformServer-*" }
+                $AppVersions_Strings = $AppFiles -replace 'PlatformServer-', '' -replace '.exe', ''
             }
             'Lifetime'
             {
-                $files = $files | Where-Object -FilterScript { $_ -like "LifeTimeWithPlatformServer-*" }
-                $versions = $files -replace 'LifeTimeWithPlatformServer-', '' -replace '.exe', ''
+                $AppFiles = $RepoFiles | Where-Object -FilterScript { $_ -like "LifeTimeWithPlatformServer-*" }
+                $AppVersions_Strings = $AppFiles -replace 'LifeTimeWithPlatformServer-', '' -replace '.exe', ''
+            }
+            'DevelopmentEnvironment'
+            {
+                $AppFiles = $RepoFiles | Where-Object -FilterScript { $_ -like "DevelopmentEnvironment-*" }
+                $AppVersions_Strings = $AppFiles -replace 'DevelopmentEnvironment-', '' -replace '.exe', ''
+            }
+            'ServiceStudio'
+            {
+                $AppFiles = $RepoFiles | Where-Object -FilterScript { $_ -like "ServiceStudio-*" }
+                $AppVersions_Strings = $AppFiles -replace 'ServiceStudio-', '' -replace '.exe', ''
+            }
+            'IntegrationStudio'
+            {
+                $AppFiles = $RepoFiles | Where-Object -FilterScript { $_ -like "IntegrationStudio-*" }
+                $AppVersions_Strings = $AppFiles -replace 'IntegrationStudio-', '' -replace '.exe', ''
             }
         }
 
         # Filter only major version and sort desc
-        $versions = [System.Version[]]($versions | Where-Object -FilterScript { $_ -like "$MajorVersion.*" }) | Sort-Object -Descending
+        $AppVersions = [System.Version[]]($AppVersions_Strings | Where-Object -FilterScript { $_ -like "$MajorVersion.*" }) | Sort-Object -Descending
 
         if ($Latest.IsPresent)
         {
             LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Returning the latest version"
-            return $versions[0].ToString()
+            return $AppVersions[0].ToString()
         }
         else
         {
-            LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Returning $($versions.Count) versions"
-            return $versions | ForEach-Object -Process { $_.ToString() }
+            LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Returning $($AppVersions.Count) versions"
+            return $AppVersions | ForEach-Object -Process { $_.ToString() }
         }
     }
 

--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -1004,10 +1004,10 @@ function GetAzStorageFileList()
     $stoContainer = ([System.Uri]$OSRepoURL).Segments[1]
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Getting file list from storage account $stoAccountName container $stoContainer"
 
-    $stoCtx = New-AzureStorageContext -StorageAccountName $stoAccountName -Anonymous -ErrorAction Stop
+    $stoCtx = New-AzStorageContext -StorageAccountName $stoAccountName -Anonymous -ErrorAction Stop
 
     $ProgressPreference = "SilentlyContinue"
-    $sources = $(Get-AzureStorageBlob -Container $stoContainer -Context $stoCtx -ErrorAction Stop).Name
+    $sources = $(Get-AzStorageBlob -Container $stoContainer -Context $stoCtx -ErrorAction Stop).Name
 
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Returning $($sources.Count)"
 

--- a/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
+++ b/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
@@ -51,7 +51,7 @@ Description = 'Tools for installing and manage the OutSystems platform installat
 ProcessorArchitecture = 'Amd64'
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @('AzureRM.Storage')
+RequiredModules = @('Az.Storage')
 
 # Assemblies that must be loaded prior to importing this module
 RequiredAssemblies = @(

--- a/test/unit/Get-OSRepoAvailableVersions.Tests.ps1
+++ b/test/unit/Get-OSRepoAvailableVersions.Tests.ps1
@@ -28,5 +28,13 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should return at least one version' { $result.Count | Should BeGreaterThan 0 }
         }
 
+        Context 'When getting Lifetime versions' {
+
+            $result = Get-OSRepoAvailableVersions -Application 'Lifetime' -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should not have errors' { $err.Count | Should Be 0 }
+            It 'Should return at least one version' { $result.Count | Should BeGreaterThan 0 }
+        }
+
     }
 }

--- a/test/unit/Get-OSRepoAvailableVersions.Tests.ps1
+++ b/test/unit/Get-OSRepoAvailableVersions.Tests.ps1
@@ -1,0 +1,32 @@
+Get-Module Outsystems.SetupTools | Remove-Module -Force
+Import-Module $PSScriptRoot\..\..\src\Outsystems.SetupTools -Force -ArgumentList $false, '', '', $false
+
+InModuleScope -ModuleName OutSystems.SetupTools {
+    Describe 'Get-OSRepoAvailableVersions Tests' {
+
+        Context 'When getting Platform Server versions' {
+
+            $result = Get-OSRepoAvailableVersions -Application 'PlatformServer' -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should not have errors' { $err.Count | Should Be 0 }
+            It 'Should return at least one version' { $result.Count | Should BeGreaterThan 0 }
+        }
+
+        Context 'When getting Service Studio versions' {
+
+            $result = Get-OSRepoAvailableVersions -Application 'ServiceStudio' -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should not have errors' { $err.Count | Should Be 0 }
+            It 'Should return at least one version' { $result.Count | Should BeGreaterThan 0 }
+        }
+
+        Context 'When getting Integration Studio versions' {
+
+            $result = Get-OSRepoAvailableVersions -Application 'IntegrationStudio' -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should not have errors' { $err.Count | Should Be 0 }
+            It 'Should return at least one version' { $result.Count | Should BeGreaterThan 0 }
+        }
+
+    }
+}


### PR DESCRIPTION
- Changes due to split of Development Environment installer to separate Service Studio and Integration Studio ones.
- Fix issues with names and version numbers incompatible with [System.Version[]]. Some files in the repository have names ending in ..exe or have version numbers not following major.minor.build.revision causing variable assignment with [System.Version[]] to fail. Fixes https://github.com/OutSystems/OutSystems.SetupTools/issues/105
- Change to Az module from AzureRM, which will be deprecated soon
https://learn.microsoft.com/en-gb/powershell/azure/migrate-from-azurerm-to-az
- Fix error when no versions matching parameters were found
