### PR TITLE
R11BRT-1724 - make msbuild optional

### DIFF
--- a/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
@@ -60,9 +60,9 @@ function Get-OSServerPreReqs
 
             $RequirementStatus = @{}
             $RequirementStatus.Title = $Title
-            $RequirementStatus.Status = $Result.Status || -not $($Result.Mandatory)
-            $RequirementStatus.OptionalsStatus = $Result.OptionalsStatus || -not $($Result.Mandatory)
-            $RequirementStatus.IISStatus = $Result.IISStatus || -not $($Result.Mandatory)
+            $RequirementStatus.Status = $Result.Status -or $(-not $($Result.Mandatory))
+            $RequirementStatus.OptionalsStatus = $Result.OptionalsStatus -or $(-not $($Result.Mandatory))
+            $RequirementStatus.IISStatus = $Result.IISStatus -or $(-not $($Result.Mandatory))
             $RequirementStatus.Installed = $Result.Status
 
             $TextStatus = "OK"

--- a/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
@@ -60,9 +60,10 @@ function Get-OSServerPreReqs
 
             $RequirementStatus = @{}
             $RequirementStatus.Title = $Title
-            $RequirementStatus.Status = $Result.Status
-            $RequirementStatus.OptionalsStatus = $Result.OptionalsStatus
-            $RequirementStatus.IISStatus = $Result.IISStatus
+            $RequirementStatus.Status = $Result.Status || -not $($Result.Mandatory)
+            $RequirementStatus.OptionalsStatus = $Result.OptionalsStatus || -not $($Result.Mandatory)
+            $RequirementStatus.IISStatus = $Result.IISStatus || -not $($Result.Mandatory)
+            $RequirementStatus.Installed = $Result.Status
 
             $TextStatus = "OK"
             if (-not $($Result.Status))
@@ -99,13 +100,17 @@ function Get-OSServerPreReqs
 
                 [Parameter(Mandatory = $true)]
                 [AllowEmptyCollection()]
-                [String[]]$NOKMessages
+                [String[]]$NOKMessages,
+
+                [Parameter(Mandatory = $false)]
+                [Bool]$Mandatory = $true
             )
 
             $Result = @{}
             $Result.Status = $Status
             $Result.OptionalsStatus = $OptionalsStatus
             $Result.IISStatus = $IISStatus
+            $Result.Mandatory = $Mandatory
 
 
             if ($Result.Status -and $Result.OptionalsStatus)
@@ -435,7 +440,7 @@ function Get-OSServerPreReqs
 
                                                             return $(CreateResult -Status $Status -OKMessages $OKMessages -NOKMessages $NOKMessages)
                                                         }
-
+        # Deprecated Build Tools is no longer mandatory in system requirements
         $RequirementStatuses += CreateRequirementStatus -Title "Microsoft Build Tools" `
                                                         -ScriptBlock `
                                                         {
@@ -444,8 +449,9 @@ function Get-OSServerPreReqs
                                                             $Status = $(IsMSBuildToolsVersionValid -MajorVersion $MajorVersion -InstallInfo $MSBuildInstallInfo)
                                                             $OKMessages = @("$($MSBuildInstallInfo.LatestVersionInstalled) is installed.")
                                                             $NOKMessages = @("No valid MS Build Tools version found, this is an OutSystems requirement.")
+                                                            $Mandatory = $false
 
-                                                            return $(CreateResult -Status $Status -OKMessages $OKMessages -NOKMessages $NOKMessages)
+                                                            return $(CreateResult -Status $Status -OKMessages $OKMessages -NOKMessages $NOKMessages -Mandatory $Mandatory)
                                                         }
 
         $RequirementStatuses += CreateRequirementStatus -Title "Windows Search Service" `

--- a/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
@@ -444,15 +444,15 @@ function Get-OSServerPreReqs
         {
             $RequirementStatuses += CreateRequirementStatus -Title "Microsoft Build Tools" `
                 -ScriptBlock `
-            {
-                $MSBuildInstallInfo = $(GetMSBuildToolsInstallInfo)
+                {
+                    $MSBuildInstallInfo = $(GetMSBuildToolsInstallInfo)
 
-                $Status = $(IsMSBuildToolsVersionValid -MajorVersion $MajorVersion -InstallInfo $MSBuildInstallInfo)
-                $OKMessages = @("$($MSBuildInstallInfo.LatestVersionInstalled) is installed.")
-                $NOKMessages = @("No valid MS Build Tools version found, this is an OutSystems requirement.")
+                    $Status = $(IsMSBuildToolsVersionValid -MajorVersion $MajorVersion -InstallInfo $MSBuildInstallInfo)
+                    $OKMessages = @("$($MSBuildInstallInfo.LatestVersionInstalled) is installed.")
+                    $NOKMessages = @("No valid MS Build Tools version found, this is an OutSystems requirement.")
 
-                return $(CreateResult -Status $Status -OKMessages $OKMessages -NOKMessages $NOKMessages)
-            }
+                    return $(CreateResult -Status $Status -OKMessages $OKMessages -NOKMessages $NOKMessages)
+                }
         }
 
 

--- a/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
@@ -60,10 +60,9 @@ function Get-OSServerPreReqs
 
             $RequirementStatus = @{}
             $RequirementStatus.Title = $Title
-            $RequirementStatus.Status = $Result.Status -or $(-not $($Result.Mandatory))
-            $RequirementStatus.OptionalsStatus = $Result.OptionalsStatus -or $(-not $($Result.Mandatory))
-            $RequirementStatus.IISStatus = $Result.IISStatus -or $(-not $($Result.Mandatory))
-            $RequirementStatus.Installed = $Result.Status
+            $RequirementStatus.Status = $Result.Status
+            $RequirementStatus.OptionalsStatus = $Result.OptionalsStatus
+            $RequirementStatus.IISStatus = $Result.IISStatus
 
             $TextStatus = "OK"
             if (-not $($Result.Status))
@@ -100,17 +99,13 @@ function Get-OSServerPreReqs
 
                 [Parameter(Mandatory = $true)]
                 [AllowEmptyCollection()]
-                [String[]]$NOKMessages,
-
-                [Parameter(Mandatory = $false)]
-                [Bool]$Mandatory = $true
+                [String[]]$NOKMessages
             )
 
             $Result = @{}
             $Result.Status = $Status
             $Result.OptionalsStatus = $OptionalsStatus
             $Result.IISStatus = $IISStatus
-            $Result.Mandatory = $Mandatory
 
 
             if ($Result.Status -and $Result.OptionalsStatus)
@@ -165,9 +160,14 @@ function Get-OSServerPreReqs
             {
                 LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Adding Microsoft Message Queueing feature to the Windows Features list since its required for OutSystems $MajorVersion"
                 $winFeatures += "MSMQ"
+
+                $requireMSBuildTools = $true
             }
             default
             {
+                # Deprecated Build Tools is no longer mandatory in system requirements
+                $requireMSBuildTools = $false
+
                 # Check .NET Core / .NET Windows Server Hosting version
                 $fullVersion = [version]"$MajorVersion.$MinorVersion.$PatchVersion.0"
                 if ($fullVersion -eq [version]"$MajorVersion.0.0.0")
@@ -440,19 +440,21 @@ function Get-OSServerPreReqs
 
                                                             return $(CreateResult -Status $Status -OKMessages $OKMessages -NOKMessages $NOKMessages)
                                                         }
-        # Deprecated Build Tools is no longer mandatory in system requirements
-        $RequirementStatuses += CreateRequirementStatus -Title "Microsoft Build Tools" `
-                                                        -ScriptBlock `
-                                                        {
-                                                            $MSBuildInstallInfo = $(GetMSBuildToolsInstallInfo)
+        if ($requireMSBuildTools)
+        {
+            $RequirementStatuses += CreateRequirementStatus -Title "Microsoft Build Tools" `
+                -ScriptBlock `
+            {
+                $MSBuildInstallInfo = $(GetMSBuildToolsInstallInfo)
 
-                                                            $Status = $(IsMSBuildToolsVersionValid -MajorVersion $MajorVersion -InstallInfo $MSBuildInstallInfo)
-                                                            $OKMessages = @("$($MSBuildInstallInfo.LatestVersionInstalled) is installed.")
-                                                            $NOKMessages = @("No valid MS Build Tools version found, this is an OutSystems requirement.")
-                                                            $Mandatory = $false
+                $Status = $(IsMSBuildToolsVersionValid -MajorVersion $MajorVersion -InstallInfo $MSBuildInstallInfo)
+                $OKMessages = @("$($MSBuildInstallInfo.LatestVersionInstalled) is installed.")
+                $NOKMessages = @("No valid MS Build Tools version found, this is an OutSystems requirement.")
 
-                                                            return $(CreateResult -Status $Status -OKMessages $OKMessages -NOKMessages $NOKMessages -Mandatory $Mandatory)
-                                                        }
+                return $(CreateResult -Status $Status -OKMessages $OKMessages -NOKMessages $NOKMessages)
+            }
+        }
+
 
         $RequirementStatuses += CreateRequirementStatus -Title "Windows Search Service" `
                                                         -ScriptBlock `

--- a/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
@@ -165,6 +165,7 @@ function Install-OSServerPreReqs
             }
             default
             {
+                # Deprecated no longer required
                 if ($InstallMSBuildTools)
                 {
                     $installBuildTools = ValidateMSBuildTools
@@ -336,7 +337,6 @@ function Install-OSServerPreReqs
             return $installResult
         }
 
-        # Deprecated no longer required
         # Install build tools 2015
         if ($installBuildTools)
         {

--- a/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
@@ -131,7 +131,7 @@ function Install-OSServerPreReqs
         # MS Buld Tools minimum version is different depending on the Platform Major Version
         # 10 : 2015 and 2015 Update 3 are allowed but 2017 is not
         # 11 : All the above three are allowed
-        if ($InstallMSBuildTools)
+        function ValidateMSBuildTools
         {
             $MSBuildInstallInfo = $(GetMSBuildToolsInstallInfo)
 
@@ -145,17 +145,37 @@ function Install-OSServerPreReqs
                 {
                     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "No valid MS Build Tools version found, this is an OutSystems requirement. We will try to download and install MS Build Tools 2015."
                 }
-    
-                $installBuildTools = $true
+                return $true
             }
             else
             {
                 LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "$($MSBuildInstallInfo.LatestVersionInstalled) found"
-    
+
                 $installResult.RebootNeeded = $MSBuildInstallInfo.RebootNeeded
             }
+
+            return $false
         }
-        
+
+        switch ($MajorVersion)
+        {
+            '10'
+            {
+                $installBuildTools = ValidateMSBuildTools
+            }
+            default
+            {
+                if ($InstallMSBuildTools)
+                {
+                    $installBuildTools = ValidateMSBuildTools
+                }
+                # Skip validation
+                else
+                {
+                    $installBuildTools = $false
+                }
+            }
+        }
 
         # Version specific pre-reqs checks.
         switch ($MajorVersion)
@@ -318,7 +338,7 @@ function Install-OSServerPreReqs
 
         # Deprecated no longer required
         # Install build tools 2015
-        if ($installBuildTools -and $InstallMSBuildTools)
+        if ($installBuildTools)
         {
             try
             {

--- a/test/unit/Install-OSServerPreReqs.Tests.ps1
+++ b/test/unit/Install-OSServerPreReqs.Tests.ps1
@@ -56,7 +56,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '10' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
-            It 'Should run the BuildToold installation' { Assert-MockCalled @assNotRunInstallBuildTools }
+            It 'Should run the BuildToold installation' { Assert-MockCalled @assRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should not run the .NET 2.1 core installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
             It 'Should not run the .NET core installation' { Assert-MockCalled @assNotRunInstallDotNetCore }
@@ -79,7 +79,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
         Context 'When installing OS 10 on a clean machine and everything succeed with MSBuild tools option' {
 
-            $result = Install-OSServerPreReqs -MajorVersion '10' -ErrorVariable err -ErrorAction SilentlyContinue -InstallMSBuildTools $true
+            $result = Install-OSServerPreReqs -MajorVersion '10' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
             It 'Should run the BuildToold installation' { Assert-MockCalled @assRunInstallBuildTools }
@@ -138,6 +138,32 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
+            It 'Should not run the BuildToold installation' { Assert-MockCalled @assNotRunInstallBuildTools }
+            It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
+            It 'Should run the .NET core 2.1 installation' { Assert-MockCalled @assRunInstallDotNetCore21 }
+            It 'Should run the .NET core installation' { Assert-MockCalled @assRunInstallDotNetCore }
+            It 'Should run the .NET 6.0 Hosting Bundle installation' { Assert-MockCalled @assRunInstallDotNetHostingBundle }
+            It 'Should run the .NET 8.0 Hosting Bundle installation' { Assert-MockCalled @assRunInstallDotNetHostingBundle8 }
+            It 'Should configure the WMI service' { Assert-MockCalled @assRunConfigureServiceWMI }
+            It 'Should configure the Windows search service' { Assert-MockCalled @assRunConfigureServiceWindowsSearch }
+            It 'Should disable the FIPS' { Assert-MockCalled @assRunDisableFIPS }
+            It 'Should configure the windows event log' { Assert-MockCalled @assRunConfigureWindowsEventLog }
+            It 'Should not configure the MSMQ' { Assert-MockCalled @assNotRunConfigureMSMQDomainServer }
+            It 'Should return the right result' {
+                $result.Success | Should Be $true
+                $result.RebootNeeded | Should Be $false
+                $result.ExitCode | Should Be 0
+                $result.Message | Should Be 'Outsystems platform server pre-requisites successfully installed'
+            }
+            It 'Should not output an error' { $err.Count | Should Be 0 }
+            It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -ErrorAction SilentlyContinue } | Should Not throw }
+        }
+
+        Context 'When installing OS 11 on a clean machine and everything succeed with InstallMSBuildTools enabled' {
+
+            $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
             It 'Should run the BuildToold installation' { Assert-MockCalled @assRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should run the .NET core 2.1 installation' { Assert-MockCalled @assRunInstallDotNetCore21 }
@@ -158,6 +184,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not output an error' { $err.Count | Should Be 0 }
             It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -ErrorAction SilentlyContinue } | Should Not throw }
         }
+
 
         Context 'When installing OS 11 with all prereqs installed' {
 
@@ -195,7 +222,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '12' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
-            It 'Should run the BuildToold installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should not run the BuildToold installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should run the .NET core 2.1 installation' { Assert-MockCalled @assRunInstallDotNetCore21 }
             It 'Should run the .NET core installation' { Assert-MockCalled @assRunInstallDotNetCore }
@@ -283,11 +310,11 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
             It 'Should run the next actions' {
                 Assert-MockCalled @assRunInstallDotNet
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunInstallDotNetCore21
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assNotRunInstallDotNetHostingBundle
@@ -461,7 +488,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             }
         }
 
-        Context 'When build tools installation fails to start' {
+        Context 'When build tools installation fails to start with InstallMSBuildTools option enabled' {
 
             Mock InstallBuildTools { throw 'Big error' }
             $result = Install-OSServerPreReqs -MajorVersion '10' -ErrorVariable err -ErrorAction SilentlyContinue
@@ -493,7 +520,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '10' -ErrorAction SilentlyContinue } | Should Not throw }
         }
 
-        Context 'When build tools installer not found' {
+        Context 'When build tools installer not found with InstallMSBuildTools option enabled' {
 
             Mock InstallBuildTools { throw [System.IO.FileNotFoundException] 'Build Tools installer not found' }
             $result = Install-OSServerPreReqs -MajorVersion '10' -ErrorVariable err -ErrorAction SilentlyContinue
@@ -525,7 +552,40 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '10' -ErrorAction SilentlyContinue } | Should Not throw }
         }
 
-        Context 'When build tools a reboot' {
+        Context 'When build tools installer not found without InstallMSBuildTools option enabled' {
+
+            Mock InstallBuildTools { throw [System.IO.FileNotFoundException] 'Build Tools installer not found' }
+            $result = Install-OSServerPreReqs -MajorVersion '10' -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should run the next actions' {
+                Assert-MockCalled @assRunInstallBuildTools
+                Assert-MockCalled @assRunInstallWindowsFeatures
+            }
+
+            It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallDotNet
+                Assert-MockCalled @assNotRunInstallDotNetCore21
+                Assert-MockCalled @assNotRunInstallDotNetCore
+                Assert-MockCalled @assNotRunInstallDotNetHostingBundle
+                Assert-MockCalled @assNotRunInstallDotNetHostingBundle8
+                Assert-MockCalled @assNotRunConfigureServiceWMI
+                Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
+                Assert-MockCalled @assNotRunDisableFIPS
+                Assert-MockCalled @assNotRunConfigureWindowsEventLog
+                Assert-MockCalled @assNotRunConfigureMSMQDomainServer
+            }
+            It 'Should return the right result' {
+                $result.Success | Should Be $false
+                $result.RebootNeeded | Should Be $false
+                $result.ExitCode | Should Be -1
+                $result.Message | Should Be 'Build Tools installer not found'
+            }
+            It 'Should output an error' { $err[-1] | Should Be 'Build Tools installer not found' }
+            It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '10' -ErrorAction SilentlyContinue } | Should Not throw }
+        }
+
+
+        Context 'When build tools a reboot with InstallMSBuildTools option enabled' {
 
             Mock InstallBuildTools { return 3010 }
             $result = Install-OSServerPreReqs -MajorVersion '10' -ErrorVariable err -ErrorAction SilentlyContinue
@@ -558,7 +618,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '10' -ErrorAction SilentlyContinue } | Should Not throw }
         }
 
-        Context 'When build tools reports an error' {
+        Context 'When build tools reports an error with InstallMSBuildTools option enabled' {
 
             Mock InstallBuildTools { return 10 }
             $result = Install-OSServerPreReqs -MajorVersion '10' -ErrorVariable err -ErrorAction SilentlyContinue
@@ -694,7 +754,6 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the next actions' {
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
@@ -703,6 +762,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assNotRunConfigureServiceWMI
                 Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
@@ -726,7 +786,6 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the next actions' {
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
@@ -734,6 +793,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assNotRunInstallDotNetHostingBundle8
                 Assert-MockCalled @assNotRunConfigureServiceWMI
@@ -758,13 +818,13 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the next actions' {
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assNotRunInstallDotNetHostingBundle
                 Assert-MockCalled @assNotRunInstallDotNetHostingBundle8
@@ -787,15 +847,15 @@ InModuleScope -ModuleName OutSystems.SetupTools {
         Context 'When .NET core 2.1 installation fails to start' {
 
             Mock -CommandName InstallDotNetCoreHostingBundle -ParameterFilter { $MajorVersion -eq "2" } -MockWith { throw 'Big error' }
-            $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue -InstallMSBuildTools $true
+            $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the next actions' {
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assNotRunInstallDotNetHostingBundle
@@ -822,7 +882,6 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the next actions' {
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
@@ -831,6 +890,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assNotRunConfigureServiceWMI
                 Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
@@ -854,7 +914,6 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the next actions' {
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
@@ -862,6 +921,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assNotRunInstallDotNetHostingBundle8
                 Assert-MockCalled @assNotRunConfigureServiceWMI
@@ -886,13 +946,13 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the next actions' {
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assNotRunInstallDotNetHostingBundle
                 Assert-MockCalled @assNotRunInstallDotNetHostingBundle8
@@ -918,12 +978,12 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the next actions' {
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assNotRunInstallDotNetHostingBundle
@@ -951,7 +1011,6 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
             It 'Should run the next actions' {
                 Assert-MockCalled @assRunInstallDotNet
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
@@ -964,6 +1023,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunConfigureMSMQDomainServer
             }
             It 'Should return the right result' {
@@ -983,7 +1043,6 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
             It 'Should run the next actions' {
                 Assert-MockCalled @assRunInstallDotNet
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
@@ -996,6 +1055,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunConfigureMSMQDomainServer
             }
 
@@ -1016,7 +1076,6 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
             It 'Should run the next actions' {
                 Assert-MockCalled @assRunInstallDotNet
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
@@ -1029,6 +1088,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunConfigureMSMQDomainServer
             }
 
@@ -1049,7 +1109,6 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
             It 'Should run the next actions' {
                 Assert-MockCalled @assRunInstallDotNet
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
@@ -1062,6 +1121,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunConfigureMSMQDomainServer
             }
 
@@ -1081,7 +1141,6 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the next actions' {
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
@@ -1090,6 +1149,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assNotRunConfigureServiceWMI
                 Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
@@ -1113,7 +1173,6 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the next actions' {
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
@@ -1121,6 +1180,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assNotRunInstallDotNetHostingBundle8
                 Assert-MockCalled @assNotRunConfigureServiceWMI
@@ -1145,13 +1205,13 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the next actions' {
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assNotRunInstallDotNetHostingBundle
                 Assert-MockCalled @assNotRunInstallDotNetHostingBundle8
@@ -1177,12 +1237,12 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the next actions' {
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
                 Assert-MockCalled @assRunInstallDotNetCore21
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunInstallDotNet
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assNotRunInstallDotNetHostingBundle
@@ -1210,7 +1270,6 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
             It 'Should run the next actions' {
                 Assert-MockCalled @assRunInstallDotNet
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
                 Assert-MockCalled @assRunInstallDotNetHostingBundle
@@ -1220,6 +1279,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunConfigureServiceWindowsSearch
                 Assert-MockCalled @assNotRunDisableFIPS
                 Assert-MockCalled @assNotRunConfigureWindowsEventLog
@@ -1242,7 +1302,6 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
             It 'Should run the next actions' {
                 Assert-MockCalled @assRunInstallDotNet
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
                 Assert-MockCalled @assRunInstallDotNetHostingBundle
@@ -1253,6 +1312,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunDisableFIPS
                 Assert-MockCalled @assNotRunConfigureWindowsEventLog
                 Assert-MockCalled @assNotRunConfigureMSMQDomainServer
@@ -1274,7 +1334,6 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
             It 'Should run the next actions' {
                 Assert-MockCalled @assRunInstallDotNet
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
                 Assert-MockCalled @assRunInstallDotNetHostingBundle
@@ -1286,6 +1345,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunConfigureWindowsEventLog
                 Assert-MockCalled @assNotRunConfigureMSMQDomainServer
             }
@@ -1307,7 +1367,6 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
             It 'Should run the next actions' {
                 Assert-MockCalled @assRunInstallDotNet
-                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallDotNetCore21
                 Assert-MockCalled @assRunInstallDotNetCore
                 Assert-MockCalled @assRunInstallDotNetHostingBundle
@@ -1320,6 +1379,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             }
 
             It 'Should NOT run the next actions' {
+                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunConfigureMSMQDomainServer
             }
             It 'Should return the right result' {
@@ -1369,7 +1429,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '12' -PatchVersion '3' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
-            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should not run the BuildTools installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should not run the .NET core 2.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
             It 'Should run the .NET core 3.1 installation' { Assert-MockCalled @assRunInstallDotNetCore }
@@ -1395,7 +1455,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '12' -PatchVersion '1' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
-            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should not run the BuildTools installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should run the .NET core 2.1 installation' { Assert-MockCalled @assRunInstallDotNetCore21 }
             It 'Should not run the .NET core 3.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore }
@@ -1421,7 +1481,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '12' -PatchVersion '2' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
-            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should not run the BuildTools installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should not run the .NET core 2.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
             It 'Should run the .NET core installation' { Assert-MockCalled @assRunInstallDotNetCore }
@@ -1447,7 +1507,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '13' -PatchVersion '0' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
-            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should not run the BuildTools installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should not run the .NET core 2.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
             It 'Should run the .NET core installation' { Assert-MockCalled @assRunInstallDotNetCore }
@@ -1473,7 +1533,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '2' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
-            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should not run the BuildTools installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should not run the .NET core 2.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
             It 'Should not run the .NET core 3.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore }
@@ -1500,7 +1560,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '0' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
-            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should not run the BuildTools installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should not run the .NET core 2.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
             It 'Should run the .NET core 3.1 installation' { Assert-MockCalled @assRunInstallDotNetCore }
@@ -1527,7 +1587,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '1' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
-            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should not run the BuildTools installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should not run the .NET core 2.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
             It 'Should not run the .NET core installation' { Assert-MockCalled @assNotRunInstallDotNetCore }
@@ -1554,7 +1614,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '25' -PatchVersion '1' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
-            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should not run the BuildTools installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should not run the .NET core 2.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
             It 'Should not run the .NET core installation' { Assert-MockCalled @assNotRunInstallDotNetCore }
@@ -1581,7 +1641,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '2' -RemovePreviousHostingBundlePackages $true -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
-            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should not run the BuildTools installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should not run the .NET core 2.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
             It 'Should not run the .NET core 3.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore }
@@ -1608,7 +1668,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '0' -RemovePreviousHostingBundlePackages $true -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
-            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should not run the BuildTools installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should not run the .NET core 2.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
             It 'Should run the .NET core 3.1 installation' { Assert-MockCalled @assRunInstallDotNetCore }
@@ -1635,7 +1695,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '1' -RemovePreviousHostingBundlePackages $true -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
-            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should not run the BuildTools installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should not run the .NET core 2.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
             It 'Should not run the .NET core installation' { Assert-MockCalled @assNotRunInstallDotNetCore }
@@ -1662,7 +1722,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '25' -PatchVersion '1' -RemovePreviousHostingBundlePackages $true -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
-            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should not run the BuildTools installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should not run the .NET core 2.1 installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
             It 'Should not run the .NET core installation' { Assert-MockCalled @assNotRunInstallDotNetCore }
@@ -1689,7 +1749,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
-            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should not run the BuildTools installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should run the .NET core 2.1 installation' { Assert-MockCalled @assRunInstallDotNetCore21}
             It 'Should run the .NET core installation' { Assert-MockCalled @assRunInstallDotNetCore }
@@ -1716,7 +1776,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '11' -RemovePreviousHostingBundlePackages $true -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
-            It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
+            It 'Should not run the BuildTools installation' { Assert-MockCalled @assNotRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should run the .NET core 2.1 installation' { Assert-MockCalled @assRunInstallDotNetCore21}
             It 'Should run the .NET core installation' { Assert-MockCalled @assRunInstallDotNetCore }

--- a/test/unit/Install-OSServerPreReqs.Tests.ps1
+++ b/test/unit/Install-OSServerPreReqs.Tests.ps1
@@ -161,7 +161,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
         Context 'When installing OS 11 on a clean machine and everything succeed with InstallMSBuildTools enabled' {
 
-            $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
+            $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue -InstallMSBuildTools $true
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
             It 'Should run the BuildToold installation' { Assert-MockCalled @assRunInstallBuildTools }
@@ -310,11 +310,11 @@ InModuleScope -ModuleName OutSystems.SetupTools {
 
             It 'Should run the next actions' {
                 Assert-MockCalled @assRunInstallDotNet
+                Assert-MockCalled @assRunInstallBuildTools
                 Assert-MockCalled @assRunInstallWindowsFeatures
             }
 
             It 'Should NOT run the next actions' {
-                Assert-MockCalled @assNotRunInstallBuildTools
                 Assert-MockCalled @assNotRunInstallDotNetCore21
                 Assert-MockCalled @assNotRunInstallDotNetCore
                 Assert-MockCalled @assNotRunInstallDotNetHostingBundle

--- a/test/unit/Install-OSServerPreReqs.Tests.ps1
+++ b/test/unit/Install-OSServerPreReqs.Tests.ps1
@@ -56,6 +56,32 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             $result = Install-OSServerPreReqs -MajorVersion '10' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
+            It 'Should run the BuildToold installation' { Assert-MockCalled @assNotRunInstallBuildTools }
+            It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
+            It 'Should not run the .NET 2.1 core installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
+            It 'Should not run the .NET core installation' { Assert-MockCalled @assNotRunInstallDotNetCore }
+            It 'Should not run the .NET 6.0 Hosting Bundle installation' { Assert-MockCalled @assNotRunInstallDotNetHostingBundle }
+            It 'Should not run the .NET 8.0 Hosting Bundle installation' { Assert-MockCalled @assNotRunInstallDotNetHostingBundle8 }
+            It 'Should configure the WMI service' { Assert-MockCalled @assRunConfigureServiceWMI }
+            It 'Should configure the Windows search service' { Assert-MockCalled @assRunConfigureServiceWindowsSearch }
+            It 'Should disable the FIPS' { Assert-MockCalled @assRunDisableFIPS }
+            It 'Should configure the windows event log' { Assert-MockCalled @assRunConfigureWindowsEventLog }
+            It 'Should configure the MSMQ' { Assert-MockCalled @assRunConfigureMSMQDomainServer }
+            It 'Should return the right result' {
+                $result.Success | Should Be $true
+                $result.RebootNeeded | Should Be $false
+                $result.ExitCode | Should Be 0
+                $result.Message | Should Be 'Outsystems platform server pre-requisites successfully installed'
+            }
+            It 'Should not output an error' { $err.Count | Should Be 0 }
+            It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '10' -ErrorAction SilentlyContinue } | Should Not throw }
+        }
+
+        Context 'When installing OS 10 on a clean machine and everything succeed with MSBuild tools option' {
+
+            $result = Install-OSServerPreReqs -MajorVersion '10' -ErrorVariable err -ErrorAction SilentlyContinue -InstallMSBuildTools $true
+
+            It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
             It 'Should run the BuildToold installation' { Assert-MockCalled @assRunInstallBuildTools }
             It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
             It 'Should not run the .NET 2.1 core installation' { Assert-MockCalled @assNotRunInstallDotNetCore21 }
@@ -76,6 +102,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not output an error' { $err.Count | Should Be 0 }
             It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '10' -ErrorAction SilentlyContinue } | Should Not throw }
         }
+
 
         Context 'When installing OS 10 on a machine with all prereqs installed' {
 
@@ -760,7 +787,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
         Context 'When .NET core 2.1 installation fails to start' {
 
             Mock -CommandName InstallDotNetCoreHostingBundle -ParameterFilter { $MajorVersion -eq "2" } -MockWith { throw 'Big error' }
-            $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue
+            $result = Install-OSServerPreReqs -MajorVersion '11' -ErrorVariable err -ErrorAction SilentlyContinue -InstallMSBuildTools $true
 
             It 'Should run the next actions' {
                 Assert-MockCalled @assRunInstallBuildTools


### PR DESCRIPTION
Make ms build optional on installations and validation of pre requisites. 
For now, we will allow for anyone that uses setup tools outside of the Platform Installer to install the old MS Build Tools