### PR TITLE
Fix Set-OSServerPerformanceTunning2 not moving PerformanceMonitor to LifeTimeAppPool

### DIFF
--- a/src/Outsystems.SetupTools/Lib/Constants.ps1
+++ b/src/Outsystems.SetupTools/Lib/Constants.ps1
@@ -191,7 +191,7 @@ $OSIISConfig = @(
     @{
         'PoolName'         = 'LifeTimeAppPool';
         'MemoryPercentage' = 60;
-        'Match'            = @('/LT*', '/lifet*', '/LifeT*', 'PerformanceMonitor')
+        'Match'            = @('/LT*', '/lifet*', '/LifeT*', '/PerformanceMonitor')
     }
 )
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]


### PR DESCRIPTION
Fix https://github.com/OutSystems/OutSystems.SetupTools/issues/131