### PR TITLE
Fix minimum Platform Server version that requires .NET 8.0 Windows Hosting Bundle

### DIFF
--- a/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
@@ -190,7 +190,7 @@ function Get-OSServerPreReqs
                     $requireDotNetHostingBundle6 = $true
                     $requireDotNetHostingBundle8 = $true
                 }
-                elseif ($fullVersion -ge [version]"11.25.1.0")  # TODO: DECIDE WHICH VERSION!!!!!
+                elseif ($fullVersion -ge [version]"11.27.0.0")
                 {
                     # Here means that minor and patch version were specified and we are equal or above version 11.25.1.0
                     # We install .NET 8.0 only

--- a/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
@@ -192,7 +192,7 @@ function Get-OSServerPreReqs
                 }
                 elseif ($fullVersion -ge [version]"11.27.0.0")
                 {
-                    # Here means that minor and patch version were specified and we are equal or above version 11.25.1.0
+                    # Here means that minor and patch version were specified and we are equal or above version 11.27.0.0
                     # We install .NET 8.0 only
                     $requireDotNetCoreHostingBundle2 = $false
                     $requireDotNetCoreHostingBundle3 = $false

--- a/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
@@ -200,7 +200,7 @@ function Install-OSServerPreReqs
                 }
                 elseif ($fullVersion -ge [version]"11.27.0.0")
                 {
-                    # Here means that minor and patch version were specified and we are equal or above version 11.25.1.0
+                    # Here means that minor and patch version were specified and we are equal or above version 11.27.0.0
                     # We install .NET 8.0 only
                     $installDotNetCoreHostingBundle2 = $false
                     $installDotNetCoreHostingBundle3 = $false

--- a/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
@@ -198,7 +198,7 @@ function Install-OSServerPreReqs
                     $installDotNetHostingBundle6 = $true
                     $installDotNetHostingBundle8 = $true
                 }
-                elseif ($fullVersion -ge [version]"11.25.1.0")  # TODO: DECIDE WHICH VERSION!!!!!
+                elseif ($fullVersion -ge [version]"11.27.0.0")
                 {
                     # Here means that minor and patch version were specified and we are equal or above version 11.25.1.0
                     # We install .NET 8.0 only

--- a/test/unit/Install-OSServerPreReqs.Tests.ps1
+++ b/test/unit/Install-OSServerPreReqs.Tests.ps1
@@ -1682,9 +1682,9 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '1' -ErrorVariable err -ErrorAction SilentlyContinue } | Should Not throw }
         }
 
-        Context 'When trying to install prerequisites for a OS 11 version in Minor version 25 and Patch version 0 (11.25.1) with RemovePreviousHostingBundlePackages flag active' {
+        Context 'When trying to install prerequisites for a OS 11 version in Minor version 27 and Patch version 0 (11.27.0) with RemovePreviousHostingBundlePackages flag active' {
 
-            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '25' -PatchVersion '1' -RemovePreviousHostingBundlePackages $true -ErrorVariable err -ErrorAction SilentlyContinue
+            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '27' -PatchVersion '0' -RemovePreviousHostingBundlePackages $true -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
             It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
@@ -1706,7 +1706,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 $result.ExitCode | Should Be 0
                 $result.Message | Should Be 'OutSystems platform server pre-requisites successfully installed'
             }
-            It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '25' -PatchVersion '1' -ErrorVariable err -ErrorAction SilentlyContinue } | Should Not throw }
+            It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '27' -PatchVersion '0' -ErrorVariable err -ErrorAction SilentlyContinue } | Should Not throw }
         }
 
         Context 'When trying to install prerequisites for a OS 11 version without passing the optional Minor and Patch Versions' {

--- a/test/unit/Install-OSServerPreReqs.Tests.ps1
+++ b/test/unit/Install-OSServerPreReqs.Tests.ps1
@@ -1574,9 +1574,9 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '17' -PatchVersion '1' -ErrorVariable err -ErrorAction SilentlyContinue } | Should Not throw }
         }
 
-        Context 'When trying to install prerequisites for a OS 11 version in Minor version 25 and Patch version 0 (11.25.1)' {
+        Context 'When trying to install prerequisites for a OS 11 version in Minor version 27 and Patch version 0 (11.27.0)' {
 
-            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '25' -PatchVersion '1' -ErrorVariable err -ErrorAction SilentlyContinue
+            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '27' -PatchVersion '0' -ErrorVariable err -ErrorAction SilentlyContinue
 
             It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
             It 'Should run the BuildTools installation' { Assert-MockCalled @assRunInstallBuildTools }
@@ -1598,7 +1598,7 @@ InModuleScope -ModuleName OutSystems.SetupTools {
                 $result.ExitCode | Should Be 0
                 $result.Message | Should Be 'OutSystems platform server pre-requisites successfully installed'
             }
-            It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '25' -PatchVersion '1' -ErrorVariable err -ErrorAction SilentlyContinue } | Should Not throw }
+            It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '27' -PatchVersion '0' -ErrorVariable err -ErrorAction SilentlyContinue } | Should Not throw }
         }
 
         Context 'When trying to install prerequisites for a OS 11 version in Minor version 17 and Patch version newer than 1 (11.17.2) with RemovePreviousHostingBundlePackages flag active' {


### PR DESCRIPTION
Set minimum version as 11.27.0 according to the system requirements documentation:
https://success.outsystems.com/documentation/11/setup_outsystems_infrastructure_and_platform/setting_up_outsystems/outsystems_system_requirements/

Fix https://github.com/OutSystems/OutSystems.SetupTools/issues/135