### PR TITLE
Fix Get-OSPlatformDeploymentZone not getting output from ExecuteCommand function

### DIFF
--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -906,6 +906,7 @@ Function ExecuteCommand([string]$CommandPath, [string]$WorkingDirectory, [string
         $Process.StartInfo = $ProcessInfo
         $Process.Start() | Out-Null
         $Process.PriorityClass = [System.Diagnostics.ProcessPriorityClass]::Idle
+        $Output = $Process.StandardOutput.ReadToEnd()
 
         if ($OnLogEvent)
         {
@@ -921,6 +922,7 @@ Function ExecuteCommand([string]$CommandPath, [string]$WorkingDirectory, [string
 
         Return [PSCustomObject]@{
             ExitCode = $Process.ExitCode
+            Output = $Output
         }
     }
     Catch


### PR DESCRIPTION
Fix https://github.com/OutSystems/OutSystems.SetupTools/issues/106