### PR TITLE
Replace use of AzureRM functions with Azure Blob Storage REST API to remove dependency of deprecated AzureRM module

### DIFF
--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -1002,14 +1002,13 @@ function GetPlatformVersion([string]$SCHost)
 
 function GetAzStorageFileList()
 {
-    $stoAccountName = (([System.Uri]$OSRepoURL).Host).Split('.')[0]
-    $stoContainer = ([System.Uri]$OSRepoURL).Segments[1]
+
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Getting file list from storage account $stoAccountName container $stoContainer"
 
-    $stoCtx = New-AzureStorageContext -StorageAccountName $stoAccountName -Anonymous -ErrorAction Stop
-
     $ProgressPreference = "SilentlyContinue"
-    $sources = $(Get-AzureStorageBlob -Container $stoContainer -Context $stoCtx -ErrorAction Stop).Name
+    [xml]$result = (Invoke-RestMethod -Uri $($OSRepoURL+"?restype=container&comp=list")).Substring(3)
+
+    $sources = $result.EnumerationResults.Blobs.Blob.Name
 
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Returning $($sources.Count)"
 

--- a/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
+++ b/src/Outsystems.SetupTools/OutSystems.SetupTools.psd1
@@ -51,7 +51,7 @@ Description = 'Tools for installing and manage the OutSystems platform installat
 ProcessorArchitecture = 'Amd64'
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @('AzureRM.Storage')
+#RequiredModules = @()
 
 # Assemblies that must be loaded prior to importing this module
 RequiredAssemblies = @(


### PR DESCRIPTION
The AzureRM PowerShell module has been deprecated since February 29, 2024.

SetupTools depends on AzureRM because of the New-AzureStorageContext and Get-AzureStorageBlob cmdlets that are used in the GetAzStorageFileList function defined in PlatformSetup.ps1.

The GetAzStorageFileList function is only used in Get-OSRepoAvailableVersions.ps1 to get the list of files in the Azure blob storage account where the repo is hosted.

By replacing the use of the cmdlets provided by AzureRM.Storage to get the list with the use of Azure Blob Storage REST API (https://learn.microsoft.com/en-us/rest/api/storageservices/blob-service-rest-api), which doesn't require any additional modules, we can remove the AzureRM dependency.