### PR TITLE
Add missing parameter to comment-based help of Install-OSServerPreReqs

### DIFF
--- a/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
@@ -35,6 +35,10 @@ function Install-OSServerPreReqs
     Specifies whether the installer should skip the installation of .NET Core Runtime and the ASP.NET Runtime.
     Accepted values: $false and $true. By default this is set to $true.
 
+    .PARAMETER InstallMSBuildTools
+    Specifies whether the installer should install Microsoft Build Tools 2015.
+    Accepted values: $false and $true. By default this is set to $false.
+
     .EXAMPLE
     Install-OSServerPreReqs -MajorVersion "10"
 


### PR DESCRIPTION
InstallMSBuildTools parameter is missing in comment-based help of Install-OSServerPreReqs function