### PR TITLE
Reuse WebServicesProxy object when getting solutions publish messages

### DIFF
--- a/src/Outsystems.SetupTools/Lib/ServiceCenterWebServices.ps1
+++ b/src/Outsystems.SetupTools/Lib/ServiceCenterWebServices.ps1
@@ -35,7 +35,7 @@ function SCWS_GetOutSystemsPlatformProxy([string]$SCHost)
 
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Connecting to $platformUri"
 
-    if ( ($null -eq $platformWS) -or ($solutionsWS.Url.Contains($SCHost) -eq $false) ) {
+    if ( ($null -eq $platformWS) -or ($platformWS.Url.Contains($SCHost) -eq $false) ) {
         $script:platformWS = New-WebServiceProxy -Uri $platformUri -ErrorAction Stop -Namespace 'OutSystems.Platform'
     }
 

--- a/src/Outsystems.SetupTools/Lib/ServiceCenterWebServices.ps1
+++ b/src/Outsystems.SetupTools/Lib/ServiceCenterWebServices.ps1
@@ -136,7 +136,9 @@ function SCWS_SolutionPack_GetPublicationMessages([string]$SCHost, [string]$SCUs
     $lastMessageId = 0
     $finished = $false
 
-    $platformServicesWS = SCWS_GetPlatformServicesProxy -SCHost $SCHost
+    if ( ($platformServicesWS -eq $null) -or ($platformServicesWS.Url.Contains($SCHost) -eq $false) ) {
+        $Script:platformServicesWS = SCWS_GetPlatformServicesProxy -SCHost $SCHost
+    }
     $result = $($platformServicesWS).SolutionPack_GetPublishMessages($SCUser, $(GetHashedPassword($SCPass)), $PublishId, $AfterMessageId, [ref]$lastMessageId, [ref]$finished)
 
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Returning messages"

--- a/src/Outsystems.SetupTools/Lib/ServiceCenterWebServices.ps1
+++ b/src/Outsystems.SetupTools/Lib/ServiceCenterWebServices.ps1
@@ -4,7 +4,11 @@ function SCWS_GetPlatformServicesProxy([string]$SCHost)
     $platformServicesUri = "http://$SCHost/ServiceCenter/PlatformServices_v8_0_0.asmx?WSDL"
 
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Connecting to $platformServicesUri"
-    $platformServicesWS = New-WebServiceProxy -Uri $platformServicesUri -ErrorAction Stop -Namespace 'OutSystems.PlatformServices'
+
+    if ( ($null -eq $platformServicesWS) -or ($platformServicesWS.Url.Contains($SCHost) -eq $false) ) {
+        $script:platformServicesWS = New-WebServiceProxy -Uri $platformServicesUri -ErrorAction Stop -Namespace 'OutSystems.PlatformServices'
+    }
+
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Connection successful"
 
     return $platformServicesWS
@@ -15,7 +19,11 @@ function SCWS_GetSolutionsProxy([string]$SCHost)
     $solutionsUri = "http://$SCHost/ServiceCenter/Solutions.asmx?WSDL"
 
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Connecting to $solutionsUri"
-    $solutionsWS = New-WebServiceProxy -Uri $solutionsUri -ErrorAction Stop -Namespace 'OutSystems.Solutions'
+
+    if ( ($null -eq $solutionsWS) -or ($solutionsWS.Url.Contains($SCHost) -eq $false) ) {
+        $script:solutionsWS = New-WebServiceProxy -Uri $solutionsUri -ErrorAction Stop -Namespace 'OutSystems.Solutions'
+    }
+
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Connection successful"
 
     return $solutionsWS
@@ -26,7 +34,11 @@ function SCWS_GetOutSystemsPlatformProxy([string]$SCHost)
     $platformUri = "http://$SCHost/ServiceCenter/OutSystemsPlatform.asmx?WSDL"
 
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Connecting to $platformUri"
-    $platformWS = New-WebServiceProxy -Uri $platformUri -ErrorAction Stop -Namespace 'OutSystems.Platform'
+
+    if ( ($null -eq $platformWS) -or ($solutionsWS.Url.Contains($SCHost) -eq $false) ) {
+        $script:platformWS = New-WebServiceProxy -Uri $platformUri -ErrorAction Stop -Namespace 'OutSystems.Platform'
+    }
+
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Connection successful"
 
     return $platformWS
@@ -136,9 +148,7 @@ function SCWS_SolutionPack_GetPublicationMessages([string]$SCHost, [string]$SCUs
     $lastMessageId = 0
     $finished = $false
 
-    if ( ($platformServicesWS -eq $null) -or ($platformServicesWS.Url.Contains($SCHost) -eq $false) ) {
-        $Script:platformServicesWS = SCWS_GetPlatformServicesProxy -SCHost $SCHost
-    }
+    $platformServicesWS = SCWS_GetPlatformServicesProxy -SCHost $SCHost
     $result = $($platformServicesWS).SolutionPack_GetPublishMessages($SCUser, $(GetHashedPassword($SCPass)), $PublishId, $AfterMessageId, [ref]$lastMessageId, [ref]$finished)
 
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Returning messages"


### PR DESCRIPTION
Reuse WebServicesProxy object when getting solutions publish messages to avoid constantly recreating it, which would cause the module to gradually increase memory utilization during execution. When publishing a large number of modules this would make the function eventually fail with an OutOfMemory error.

In my tests publishing 364 modules, the function would reach about 4GB of memory use and then fail with the same OutOfMEmory error reported in issue #102.
After this change, the same solution publish finished successfully and the memory use of powershell.exe was constant and always around 100MB.