### PR TITLE
Fix issues with Get-OSRepoAvailableVersions

### DIFF
--- a/src/Outsystems.SetupTools/Functions/Get-OSRepoAvailableVersions.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSRepoAvailableVersions.ps1
@@ -102,15 +102,19 @@ function Get-OSRepoAvailableVersions
         # Filter only major version and sort desc
         $versions = [System.Version[]]($versions | Where-Object -FilterScript { $_ -like "$MajorVersion.*" }) | Sort-Object -Descending
 
-        if ($Latest.IsPresent)
+        if ( ($versions.Count -gt 0) -and $Latest.IsPresent)
         {
             LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Returning the latest version"
             return $versions[0].ToString()
         }
-        else
+        elseif ($versions.Count -gt 0)
         {
             LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Returning $($versions.Count) versions"
             return $versions | ForEach-Object -Process { $_.ToString() }
+        }
+        else {
+            LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "No versions returned."
+            return $null
         }
     }
 

--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -1006,7 +1006,8 @@ function GetAzStorageFileList()
     LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 2 -Message "Getting file list from storage account $stoAccountName container $stoContainer"
 
     $ProgressPreference = "SilentlyContinue"
-    [xml]$result = (Invoke-RestMethod -Uri $($OSRepoURL+"?restype=container&comp=list")).Substring(3)
+    # The response is a XML but encoded in UTF-8 BOM, which is not correctly handled so the BOM is removed from the beginning of the file
+    [xml]$result = (Invoke-RestMethod -Uri $($OSRepoURL+"?restype=container&comp=list")).TrimStart([char[]](0xEF,0xBB,0xBF,0xFEFF))
 
     $sources = $result.EnumerationResults.Blobs.Blob.Name
 


### PR DESCRIPTION
Fix removal of UTF8 BOM in XML response for compatibility with PowerShell 6.0+, the previous method only worked for WindowsPowershell

Fix "Cannot index into a null array" error when no versions matching parameters were found in the repository.
Example: Get-OSRepoAvailableVersions -Application ServiceStudio -MajorVersion 10
