### PR TITLE
Skip Service Center validation for first installs. 

### DIFF
--- a/src/Outsystems.SetupTools/Functions/Set-OSServerPerformanceTunning2.ps1
+++ b/src/Outsystems.SetupTools/Functions/Set-OSServerPerformanceTunning2.ps1
@@ -365,6 +365,7 @@ function Set-OSServerPerformanceTunning2
                     return
                 }
             }
+        }
 
         # Configure HTTP Compression folder (Server Level)
         if ($IISHttpCompressionPath)

--- a/src/Outsystems.SetupTools/Functions/Set-OSServerPerformanceTunning2.ps1
+++ b/src/Outsystems.SetupTools/Functions/Set-OSServerPerformanceTunning2.ps1
@@ -365,6 +365,19 @@ function Set-OSServerPerformanceTunning2
                     return
                 }
             }
+
+            LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Changing IIS compilation folder to $IISNetCompilationPath"
+            try
+            {
+                SetWebConfigurationProperty -PSPath "MACHINE/WEBROOT" -Filter "system.web/compilation" -Name 'tempDirectory' -Value $IISNetCompilationPath
+            }
+            catch
+            {
+                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Exception $_.Exception -Stream 3 -Message "Error setting the IIS compilation folder"
+                WriteNonTerminalError -Message "Error setting the IIS compilation folder"
+
+                return
+            }
         }
 
         # Configure HTTP Compression folder (Server Level)

--- a/src/Outsystems.SetupTools/Functions/Set-OSServerPerformanceTunning2.ps1
+++ b/src/Outsystems.SetupTools/Functions/Set-OSServerPerformanceTunning2.ps1
@@ -154,7 +154,7 @@ function Set-OSServerPerformanceTunning2
             return
         }
 
-        if ( $null -eq (Get-OSPlatformVersion -ErrorAction Ignore) ) {
+        if ($(-not $SkipPlatformCheck) -and ($null -eq (Get-OSPlatformVersion -ErrorAction Ignore))) {
 
             LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 3 -Message "Service Center is not installed or not accessible"
             WriteNonTerminalError -Message "Service Center is not installed or not accessible"
@@ -365,36 +365,6 @@ function Set-OSServerPerformanceTunning2
                     return
                 }
             }
-
-            # Grant Modify permissions on the directory to the local IIS_IUSRS group
-            try
-            {
-                $Path_ACL = Get-ACL -Path $IISNetCompilationPath
-                $Path_ACLRule = New-Object System.Security.AccessControl.FileSystemAccessRule("IIS_IUSRS","Modify","ContainerInherit, ObjectInherit","None","Allow")
-                $Path_ACL.SetAccessRule($Path_ACLRule)
-                Set-Acl -Path $IISNetCompilationPath -AclObject $Path_ACL
-            }
-            catch
-            {
-                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Exception $_.Exception -Stream 3 -Message "Error setting permissions on the IIS Net compilation folder"
-                WriteNonTerminalError -Message "Error setting permissions on the IIS Net compilation folder"
-
-                return
-            }
-
-            LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Stream 0 -Message "Changing IIS compilation folder to $IISNetCompilationPath"
-            try
-            {
-                SetWebConfigurationProperty -PSPath "MACHINE/WEBROOT" -Filter "system.web/compilation" -Name 'tempDirectory' -Value $IISNetCompilationPath
-            }
-            catch
-            {
-                LogMessage -Function $($MyInvocation.Mycommand) -Phase 1 -Exception $_.Exception -Stream 3 -Message "Error setting the IIS compilation folder"
-                WriteNonTerminalError -Message "Error setting the IIS compilation folder"
-
-                return
-            }
-        }
 
         # Configure HTTP Compression folder (Server Level)
         if ($IISHttpCompressionPath)


### PR DESCRIPTION
Skip Service Center validation for first installs.
Remove code that modify permissions, this should be something customers handle.