### PR TITLE
R11BRT-2001 - InstallPS not showing ConfigurationTool Output fixed

### DIFF
--- a/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
+++ b/src/Outsystems.SetupTools/Lib/PlatformSetup.ps1
@@ -779,16 +779,16 @@ Function ExecuteCommand([string]$CommandPath, [string]$WorkingDirectory, [string
         $Process = New-Object System.Diagnostics.Process
         $Process.StartInfo = $ProcessInfo
         $Process.Start() | Out-Null
-        $Process.PriorityClass = [System.Diagnostics.ProcessPriorityClass]::Idle
-        $Output = $Process.StandardOutput.ReadToEnd()
-
+        $Process.PriorityClass = [System.Diagnostics.ProcessPriorityClass]::Idle  
+        
         if ($OnLogEvent)
         {
             do
             {
                 # Keep redirecting output until process exits
-                $OnLogEvent.Invoke($process.StandardOutput.ReadLine());
-
+                $OutputLine = $process.StandardOutput.ReadLine();
+                $Output+="$OutputLine`n";
+                $OnLogEvent.Invoke($OutputLine);
             } until ($process.HasExited)
         }
 


### PR DESCRIPTION
First run of Get-OSPlatformDeploymentZone (without Sergio Miranda fix)
Second run of Get-OSPlatformDeploymentZone (with Sergio Miranda fix)
Third run of Get-OSPlatformDeploymentZone (with these changes)

<img width="1148" height="263" alt="image" src="https://github.com/user-attachments/assets/f7949328-de9c-4250-8536-b0010a51d71e" />

These changes were also tested with InstallPS and everything is working as intended