### PR TITLE
feature -  prepare setup tools for the release of Net 11 Hosting Bundle

### DIFF
--- a/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Get-OSServerPreReqs.ps1
@@ -186,7 +186,13 @@ function Get-OSServerPreReqs
 
         # Check .NET Core / .NET Windows Server Hosting version
         $fullVersion = [version]"$MajorVersion.$MinorVersion.$PatchVersion.0"
-        if ($fullVersion -ge [version]"11.40.2.0")
+        if ($fullVersion -ge [version]"11.42.0.0")
+        {
+            $requireDotNetHostingBundle6 = $false
+            $requireDotNetHostingBundle8Or11 = $true
+            $requireDotNetHostingBundle10 = $false
+        }
+        elseif ($fullVersion -ge [version]"11.40.2.0")
         {
             $requireDotNetHostingBundle6 = $false
             $requireDotNetHostingBundle8 = $true
@@ -267,6 +273,51 @@ function Get-OSServerPreReqs
                                                                 }
                                                                 $OKMessages = @("Minimum .NET 8.0.0 Windows Server Hosting found.")
                                                                 $NOKMessages = @("Minimum .NET 8.0.0 Windows Server Hosting not found.")
+                                                                $IISStatus = $True
+
+                                                                if (Get-Command Get-WebGlobalModule -errorAction SilentlyContinue)
+                                                                {
+                                                                    $aspModules = Get-WebGlobalModule | Where-Object { $_.Name -eq "aspnetcoremodulev2" }
+                                                                    if ($Status)
+                                                                    {
+                                                                        # Check if IIS can find ASP.NET modules
+                                                                        if ($aspModules.Count -lt 1)
+                                                                        {
+                                                                            $Status = $False
+                                                                            $IISStatus = $False
+                                                                            $NOKMessages = @("IIS can't find ASP.NET modules")
+                                                                        }
+                                                                        else
+                                                                        {
+                                                                            $IISStatus = $True
+                                                                        }
+                                                                    }
+                                                                }
+
+
+                                                                return $(CreateResult -Status $Status -IISStatus $IISStatus -OKMessages $OKMessages -NOKMessages $NOKMessages)
+                                                            }
+        }
+
+        if ($requireDotNetHostingBundle8Or11) {
+            $RequirementStatuses += CreateRequirementStatus -Title ".NET 8.0 or 11.0 Windows Server Hosting" `
+                                                            -ScriptBlock `
+                                                            {
+                                                                $Status = $False
+                                                                foreach ($version in GetDotNetHostingBundleVersions)
+                                                                {
+                                                                    # Check version 8.0
+                                                                    if (([version]$version).Major -eq 8 -and ([version]$version) -ge [version]$script:OSDotNetHostingBundleReq['8']['Version']) {
+                                                                        $Status = $True
+                                                                    }
+
+                                                                     # Check version 11.0
+                                                                    if (([version]$version).Major -eq 11 -and ([version]$version) -ge [version]$script:OSDotNetHostingBundleReq['11']['Version']) {
+                                                                        $Status = $True
+                                                                    }
+                                                                }
+                                                                $OKMessages = @("Minimum .NET 8.0.0 or 11.0.0 Windows Server Hosting found.")
+                                                                $NOKMessages = @("Minimum .NET 8.0.0 or 11.0.0 Windows Server Hosting not found.")
                                                                 $IISStatus = $True
 
                                                                 if (Get-Command Get-WebGlobalModule -errorAction SilentlyContinue)

--- a/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
+++ b/src/Outsystems.SetupTools/Functions/Install-OSServerPreReqs.ps1
@@ -197,6 +197,12 @@ function Install-OSServerPreReqs
             $installDotNetHostingBundle10 = $false
             # We do not set recent hosting bundle because we don't know the version we are to uninstall the others
         }
+        elseif ($fullVersion -ge [version]"11.42.0.0")
+        {
+            $installDotNetHostingBundle6 = $false
+            $installDotNetHostingBundle8 = $true
+            $installDotNetHostingBundle10 = $false
+        }
         elseif ($fullVersion -ge [version]"11.40.2.0")
         {
             # Here means that minor and patch version were specified and we are equal or above version 11.27.0.0
@@ -237,6 +243,10 @@ function Install-OSServerPreReqs
             # Check .NET 10.0
             if (([version]$version).Major -eq 10 -and ([version]$version) -ge [version]$script:OSDotNetHostingBundleReq['10']['Version']) {
                 $installDotNetHostingBundle10 = $false
+            }
+            # Check .NET 10.0
+            if (([version]$version).Major -eq 11 -and ([version]$version) -ge [version]$script:OSDotNetHostingBundleReq['11']['Version']) {
+                $installDotNetHostingBundle8 = $false # We don't install DotNet 11 yet but we accept it
             }
         }
 

--- a/src/Outsystems.SetupTools/Lib/Constants.ps1
+++ b/src/Outsystems.SetupTools/Lib/Constants.ps1
@@ -116,6 +116,11 @@ $OSDotNetHostingBundleReq = @{
         ToInstallDownloadURL = 'https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.2/dotnet-hosting-10.0.2-win.exe'
         InstallerName = 'DotNet_WindowsHosting_10.exe'
     }
+    '11' = @{
+        Version = '11.0.0'
+        ToInstallDownloadURL = 'https://download.visualstudio.microsoft.com/download/pr/2a7ae819-fbc4-4611-a1ba-f3b072d4ea25/32f3b931550f7b315d9827d564202eeb/dotnet-hosting-8.0.0-win.exe'
+        InstallerName = 'DotNet_WindowsHosting_8.exe'
+    }
 }
 
 # .NET Core Uninstall Tool related

--- a/test/unit/Install-OSServerPreReqs.Tests.ps1
+++ b/test/unit/Install-OSServerPreReqs.Tests.ps1
@@ -1136,7 +1136,60 @@ InModuleScope -ModuleName OutSystems.SetupTools {
             It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '27' -PatchVersion '0' -ErrorVariable err -ErrorAction SilentlyContinue } | Should Not throw }
         }
 
-        # .Net 10 Hosting Bundle region
+        # .Net Hosting Bundle region
+        Context 'When trying to install prerequisites for a OS 11 version in Minor version 42 and Patch version 0 (11.42.0) with .Net 11 Hosting Bundle installed' {
+
+            Mock GetDotNet4Version { return 461808 }
+            Mock GetDotNetHostingBundleVersions { return '11.0.0' }
+
+            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '42' -PatchVersion '0' -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should not run the .NET installation' { Assert-MockCalled @assNotRunInstallDotNet }
+            It 'Should not run the BuildTools installation' { Assert-MockCalled @assNotRunInstallBuildTools }
+            It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
+            It 'Should not run the .NET 6.0 Hosting Bundle installation' { Assert-MockCalled @assNotRunInstallDotNetHostingBundle }
+            It 'Should not run the .NET 8.0 Hosting Bundle installation' { Assert-MockCalled @assNotRunInstallDotNetHostingBundle8 }
+            It 'Should not run the .NET 10.0 Hosting Bundle installation' { Assert-MockCalled @assNotRunInstallDotNetHostingBundle10 }
+            It 'Should not run the .NET Core Uninstall Tool installation' { Assert-MockCalled @assNotRunInstallDotNetCoreUninstallTool }
+            It 'Should configure the WMI service' { Assert-MockCalled @assRunConfigureServiceWMI }
+            It 'Should configure the Windows search service' { Assert-MockCalled @assRunConfigureServiceWindowsSearch }
+            It 'Should not disable the FIPS' { Assert-MockCalled @assNotRunDisableFIPS }
+            It 'Should configure the windows event log' { Assert-MockCalled @assRunConfigureWindowsEventLog }
+
+            It 'Should return the right result' {
+                $result.Success | Should Be $true
+                $result.RebootNeeded | Should Be $false
+                $result.ExitCode | Should Be 0
+                $result.Message | Should Be 'OutSystems platform server pre-requisites successfully installed'
+            }
+            It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '42' -PatchVersion '0' -ErrorVariable err -ErrorAction SilentlyContinue } | Should Not throw }
+        }
+
+        Context 'When trying to install prerequisites for a OS 11 version in Minor version 42 and Patch version 0 (11.42.0) without .Net Hosting Bundle installed' {
+
+            $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '42' -PatchVersion '0' -ErrorVariable err -ErrorAction SilentlyContinue
+
+            It 'Should run the .NET installation' { Assert-MockCalled @assRunInstallDotNet }
+            It 'Should not run the BuildTools installation' { Assert-MockCalled @assNotRunInstallBuildTools }
+            It 'Should install the windows features installation' { Assert-MockCalled @assRunInstallWindowsFeatures }
+            It 'Should not run the .NET 6.0 Hosting Bundle installation' { Assert-MockCalled @assNotRunInstallDotNetHostingBundle }
+            It 'Should run the .NET 8.0 Hosting Bundle installation' { Assert-MockCalled @assRunInstallDotNetHostingBundle8 }
+            It 'Should not run the .NET 10.0 Hosting Bundle installation' { Assert-MockCalled @assNotRunInstallDotNetHostingBundle10 }
+            It 'Should not run the .NET Core Uninstall Tool installation' { Assert-MockCalled @assNotRunInstallDotNetCoreUninstallTool }
+            It 'Should configure the WMI service' { Assert-MockCalled @assRunConfigureServiceWMI }
+            It 'Should configure the Windows search service' { Assert-MockCalled @assRunConfigureServiceWindowsSearch }
+            It 'Should not disable the FIPS' { Assert-MockCalled @assNotRunDisableFIPS }
+            It 'Should configure the windows event log' { Assert-MockCalled @assRunConfigureWindowsEventLog }
+
+            It 'Should return the right result' {
+                $result.Success | Should Be $true
+                $result.RebootNeeded | Should Be $false
+                $result.ExitCode | Should Be 0
+                $result.Message | Should Be 'OutSystems platform server pre-requisites successfully installed'
+            }
+            It 'Should not throw' { { Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '42' -PatchVersion '0' -ErrorVariable err -ErrorAction SilentlyContinue } | Should Not throw }
+        }
+
         Context 'When trying to install prerequisites for a OS 11 version in Minor version 40 and Patch version 2 (11.40.2)' {
 
             $result = Install-OSServerPreReqs -MajorVersion '11' -MinorVersion '40' -PatchVersion '2' -ErrorVariable err -ErrorAction SilentlyContinue


### PR DESCRIPTION
Due to the regressions identified in Net 10, we cannot move forward to support Net 10. Up until this point, it seems Microsoft is not going to bring these fixes to Net 10 however they are fixed in Net 11 Preview 3 already.

As such, we are preparing Setup Tools for the release of Net 11 expected to release in November around the same time Net 8 is deprecated.

Setup Tools is going to accept Net 11 but it is not going to install it until Net 11 is actually released. So a new version of Setup Tools is expected after the release of Net 11 to automatically install it.

[IIS dotnet process shutdown with .NET 10 runtime installation · Issue #64808 · dotnet/aspnetcore](https://github.com/dotnet/aspnetcore/issues/64808) 
[Regression: ANCM: Unexpected application shutdown · Issue #58939 · dotnet/aspnetcore](https://github.com/dotnet/aspnetcore/issues/58939#event-15427958100) 
[Fix IIS recycle regressions by BrennanConroy · Pull Request #59998 · dotnet/aspnetcore](https://github.com/dotnet/aspnetcore/pull/59998)